### PR TITLE
Add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+![GitHub deployments](https://img.shields.io/github/deployments/slub/librml/github-pages?label=deployment)
+![GitHub License](https://img.shields.io/github/license/slub/librml)
+
 This repository contains the source code for [librml.org](https://librml.org).
 
 Check out the website directly for more information about LibRML.


### PR DESCRIPTION
This adds badges for deployment state and license to the head of the readme.

![GitHub deployments](https://img.shields.io/github/deployments/slub/librml/github-pages?label=deployment&link=librml.org)
