### PR TITLE
Example without attributes "id" and "copyright". 

### DIFF
--- a/examples/collum.xml
+++ b/examples/collum.xml
@@ -1,6 +1,5 @@
 <libRML:LibRML xmlns:libRML="https://librml.org/schema">
-    <libRML:item tenant="https://www.slub-dresden.de/"
-        usageguide="https://nutzungshinweis.slub-dresden.de/na-co/1.0/">
+    <libRML:item usageguide="https://nutzungshinweis.slub-dresden.de/na-co/1.0/">
         <libRML:action type="displaymetadata" permission="true">
             <libRML:restriction type="mets" metssection="amdSec | dmdSec | structMap" />
         </libRML:action>


### PR DESCRIPTION
Could we create examples without "id" and "copyright", when LibRML is embedded in the metadata file? 
I did not apply them in https://github.com/slub/librml/discussions/30#discussion-9107666.
I also wonder if "tenant" is necessary.