### PR TITLE
Align JSON Schema with XSD

### DIFF
--- a/schema/librml.json
+++ b/schema/librml.json
@@ -55,6 +55,12 @@
             "format": "date",
             "type": "string"
           },
+          "groups": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "inside": {
             "items": {
               "type": "string"
@@ -82,6 +88,10 @@
               "type": "string"
             },
             "type": "array"
+          },
+          "parts": {
+            "minimum": 1,
+            "type": "integer"
           },
           "permission": {
             "type": "boolean"


### PR DESCRIPTION
There were a few things missing in the LibRML JSON Schema. This is an attempt to align the two more closely.