### PR TITLE
fix typo

### DIFF
--- a/schema/attributes.md
+++ b/schema/attributes.md
@@ -43,7 +43,7 @@ In LibRML stehen folgende Eigenschaften zur Verfügung.
 | parts | Teile der Ressource. | non-negative Integer | **Einheit**: — |
 | groups | Gruppen, auf die eine Constraint zutrifft. | Tokenliste  | **Einheit**: — |
 
-## Abhängigkeiten wischen Attributes, Constraints und Actions
+## Abhängigkeiten zwischen Attributes, Constraints und Actions
 
 | Attribut | Constraint | Action |
 | :--------- | :--------- | :--------- |


### PR DESCRIPTION
I ask myself, if it is better to create an own page for the section `Abhängigkeiten zwischen Attributes, Constraints und Actions`. 

It is part of `attributes.md`, although it contains information about actions, constraints and attributes. 