### PR TITLE
Drop headings for code snippets

### DIFF
--- a/schema/actions.md
+++ b/schema/actions.md
@@ -7,8 +7,6 @@ Sie müssen in der LibRML-Beschreibung enthalten sein [(siehe LibRML Konzept)](c
 
 `actions` können zusätzlich durch Einschränkungen [(siehe Constraints)](constraints.md) und Eigenschaften [(siehe Attributes)](attributes.md) spezifiziert werden.
 
-### XML
-
 ```xml
 <libRML version="0.4" xmlns="http://librml.org/schema">
   <item id="ID-NAME">
@@ -16,8 +14,6 @@ Sie müssen in der LibRML-Beschreibung enthalten sein [(siehe LibRML Konzept)](c
   </item>
 </libRML>
 ```
-
-### JSON
 
 ```json
 {

--- a/schema/attributes.md
+++ b/schema/attributes.md
@@ -5,13 +5,9 @@
 Eigenschaften (`attributes`) spezifizieren die Einschränkungen (`constraints`) von Nutzungsarten (`actions`).
 Jeder Eigenschaft **muss** ein Wert zugewiesen werden. Einschränkungen können mehreren Eigenschaften zugewiesen werden.
 
-### XML
-
 ```xml
 <restriction type="CONSTRAINT-NAME" ATTRIBUT-NAME="WERT"/>
 ```
-
-### JSON
 
 ```json
 "restrictions": [{

--- a/schema/constraints.md
+++ b/schema/constraints.md
@@ -7,15 +7,11 @@ Die Einschränkungen gelten ausdrücklich nur für die `action`, der sie zugewie
 
 Einschränkungen können durch [Attributes (Eigenschaften)](attributes.md) weiter spezifiziert werden.
 
-### XML
-
 ```xml
   <action type="ACTION-NAME" permission="true">
     <restriction type="CONSTRAINT-NAME" ATTRIBUT-NAME="WERT"/>
   </action>
 ```
-
-### JSON
 
 ```json
   "actions": [{

--- a/schema/header.md
+++ b/schema/header.md
@@ -32,16 +32,12 @@ Im Fall einer gebräuchlichen Lizenz ist es möglich, die [Vorlage](../tmpl/temp
 Ein urheberrechtsgeschütztes digitales Objekt, das im Kontext der SLUB Dresden lizenziert ist. Das digitale Objekt erfordert eine Namensnennung; Weiternutzung und Verbreitung unterliegen denselben Einschränkungen wie das Original.\
 So einem digitalen Objekt würde folgende LibRML zugewiesen werden.
 
-**XML**
-
 ```xml
 <libRML version="0.4" xmlns="http://librml.org/schema">
   <item id="id-123456" tenant="https://www.slub-dresden.de/" mention="true" sharealike="true" copyright="true">
   </item>
 </libRML>
 ```
-
-**JSON**
 
 ```json
 {


### PR DESCRIPTION
This is a test with dropping the "XML" and "JSON" headings for the code snippets in the schema section. If we're happy with the outcome, I will remove those on the other pages as well.
