### PR TITLE
Add mimetype

### DIFF
--- a/usage/embedded.md
+++ b/usage/embedded.md
@@ -17,7 +17,7 @@ In METS wird der XML-Code im Element `<rightsMD>` eingetragen.
   <mets:metsHdr[...]/>
   <mets:amdSec>
     <mets:rightsMD ID="RMD1">
-      <mets:mdWrap MDTYPE="OTHER" OTHERMDTYPE="LibRML">
+      <mets:mdWrap MDTYPE="OTHER" MIMETYPE="text/xml" OTHERMDTYPE="LibRML">
         <!--Here, LibRML can be embedded.-->
       </mets:mdWrap>
     </mets:rightsMD>
@@ -100,7 +100,7 @@ Die folgenden Beispiele nutzen das LibRML [Zugang nur innerhalb eines IP-Adressb
   <mets:metsHdr[...]/>
   <mets:amdSec>
     <mets:rightsMD ID="RMD1">
-      <mets:mdWrap MDTYPE="OTHER" OTHERMDTYPE="LibRML">
+      <mets:mdWrap MDTYPE="OTHER" MIMETYPE="text/xml" OTHERMDTYPE="LibRML">
         <libRML:libRML version="0.4" xmlns:libRML="http://librml.org/schema">
           <libRML:item commercialuse="false">
             <libRML:action type="displaymetadata" permission="true"/>

--- a/usage/reference_usage.md
+++ b/usage/reference_usage.md
@@ -23,7 +23,7 @@ In METS wird der URI der standardisierten Rechteinformation im Element `<mets:md
 ```xml
 <mets:amdSec>
   <mets:rightsMD ID="RMD1">
-    <mets:mdRef LABEL="Zugang nur zu Metadaten" xlink:href="https://librml.org/examples/metadataonly.html" LOCTYPE="PURL" MDTYPE="OTHER" OTHERMDTYPE="LibRML"/>
+    <mets:mdRef LABEL="Zugang nur zu Metadaten" xlink:href="https://librml.org/examples/metadataonly.html" LOCTYPE="PURL" MDTYPE="OTHER" MIMETYPE="text/xml" OTHERMDTYPE="LibRML"/>
   </mets:rightsMD>
 </mets:amdSec>
 ```


### PR DESCRIPTION
This adds `MIMETYPE` attributes to the METS examples. 
I'm not completely sure though if we need it in `reference_usage` where actually nothing is embedded.