### PR TITLE
Adjust mets:rightsMD ID from "RMD1" to "LibRML"

### DIFF
--- a/usage/embedded.md
+++ b/usage/embedded.md
@@ -16,7 +16,7 @@ In METS wird der XML-Code im Element `<rightsMD>` eingetragen.
 <mets:mets[...]>
   <mets:metsHdr[...]/>
   <mets:amdSec>
-    <mets:rightsMD ID="RMD1">
+    <mets:rightsMD ID="LibRML">
       <mets:mdWrap MDTYPE="OTHER" MIMETYPE="text/xml" OTHERMDTYPE="LibRML">
         <!--Here, LibRML can be embedded.-->
       </mets:mdWrap>
@@ -99,7 +99,7 @@ Die folgenden Beispiele nutzen das LibRML [Zugang nur innerhalb eines IP-Adressb
 <mets:mets[...]>
   <mets:metsHdr[...]/>
   <mets:amdSec>
-    <mets:rightsMD ID="RMD1">
+    <mets:rightsMD ID="LibRML">
       <mets:mdWrap MDTYPE="OTHER" MIMETYPE="text/xml" OTHERMDTYPE="LibRML">
         <libRML:libRML version="0.4" xmlns:libRML="http://librml.org/schema">
           <libRML:item commercialuse="false">

--- a/usage/reference_licence.md
+++ b/usage/reference_licence.md
@@ -47,7 +47,7 @@ In METS wird der URI der standardisierten Rechteinformation im Element `<mets:md
 
 ```xml
 <mets:amdSec>
-  <mets:rightsMD ID="RMD1">
+  <mets:rightsMD ID="LibRML">
     <mets:mdRef LABEL="CC BY 4.0" xlink:href="https://creativecommons.org/licenses/by/4.0/" LOCTYPE="PURL" MDTYPE="OTHER" OTHERMDTYPE="Creative Commons"/>
   </mets:rightsMD>
 </mets:amdSec>

--- a/usage/reference_usage.md
+++ b/usage/reference_usage.md
@@ -22,7 +22,7 @@ In METS wird der URI der standardisierten Rechteinformation im Element `<mets:md
 
 ```xml
 <mets:amdSec>
-  <mets:rightsMD ID="RMD1">
+  <mets:rightsMD ID="LibRML">
     <mets:mdRef LABEL="Zugang nur zu Metadaten" xlink:href="https://librml.org/examples/metadataonly.html" LOCTYPE="PURL" MDTYPE="OTHER" MIMETYPE="text/xml" OTHERMDTYPE="LibRML"/>
   </mets:rightsMD>
 </mets:amdSec>


### PR DESCRIPTION
The Is adjusted from "RMD1" to "LibRML", because it cannot be ensured, that the `<mets:rightsMD>` element is the first one in `<mets:amdSec>`. 
With the ID "LibRML", it is also clear, what the element contains. 