### PR TITLE
add header attribute for derivatives

### DIFF
--- a/schema/header.md
+++ b/schema/header.md
@@ -21,6 +21,7 @@ Zudem können generelle Einschränkungen und/oder Eigenschaften definiert werden
 | :--- | :----------- | :--- | :----------------- |
 | **commercialuse** | Kommerzielle Nutzung erlaubt | true/false | optional |
 | **copyright** | Urheberrechtsschutz vorhanden | true/false | optional |
+| **derivatives** | Bearbeitungen erlaubt | true/false | optional |
 | **mention** | Ist eine Namensnennung notwendig | true/false | optional |
 | **sharealike** | Verpflichtung, alle Derivate des digitalen Objektes unter denselben Bedingungen zu veröffentlichen | true/false | optional |
 

--- a/schema/librml.json
+++ b/schema/librml.json
@@ -164,6 +164,9 @@
     "copyright": {
       "type": "boolean"
     },
+    "derivatives": {
+      "type": "boolean"
+    },
     "id": {
       "type": "string"
     },

--- a/schema/librml.xsd
+++ b/schema/librml.xsd
@@ -26,6 +26,7 @@
         <xs:attribute type="xs:boolean" name="mention" />
         <xs:attribute type="xs:boolean" name="sharealike" />
         <xs:attribute type="xs:boolean" name="commercialuse" />
+        <xs:attribute type="xs:boolean" name="derivatives" />
         <xs:attribute type="xs:boolean" name="copyright" />
         <xs:attribute type="xs:string" name="template" />
         <xs:attribute type="xs:anyURI" name="usageguide" />


### PR DESCRIPTION
In CC licenses it's `NonCommercial` but we use `commercialuse`, so I propose to add `derivatives` over `NoDerivatives`.

Closes #89
