### PR TITLE
re-order tables for actions, constraints and attributes

### DIFF
--- a/schema/actions.md
+++ b/schema/actions.md
@@ -31,17 +31,17 @@ In LibRML stehen folgende Nutzungsarten zur Verfügung.
 
 | Action-Name | Übersetzung | Beschreibung |
 | :---------- | :--------- | :----------- |
-| **displaymetadata** | Anzeigen der Metadaten | Erlaubt ausschließlich die Anzeige der Metadaten im Katalog. |
-| **read** | „Lesen“ der Datei | Erlaubt das Öffnen und Lesen des digitalen Objekts. |
-| **run** | Ausführen | Erlaubt das Ausführen des digitalen Objekts z. B. einer Anwendung. |
-| **lend** | Verleih | Erlaubt den Verleih des digitalen Objekts.<br/><br/>Auf Einrichtungen bezogen. |
-| **download** | Herunterladen | Erlaubt das Herunterladen einer Datei auf einen Computer oder auf jeglichen anderen Datenträger. |
-| **print** | Ausdrucken | Erlaubt das Ausdrucken des Werkes. |
-| **reproduce** | Vervielfältigen | Erlaubt die private und öffentliche Vervielfältigung des digitalen Objekts, unabhängig davon, ob sie verbreitet wird oder nicht. |
-| **modify** | Bearbeiten | Erlaubt jede Art der Bearbeitung, Übersetzung, Umarbeitung. |
-| **reuse** | Wiederverwenden | Erlaubt die Wiederverwendung des ganzen Werkes oder Teile des Werkes. |
-| **distribute** | (Ver)teilen | Erlaubt das nicht-öffentliche Verbreiten des digitalen Objekts, wie zum Beispiel durch die Weitergabe des digitalen Objekts im Bekanntenkreis. |
-| **publish** | Veröffentlichen oder vorführen | Erlaubt das öffentliche Verbreiten oder Vorführen des digitalen Objekts, wie zum Beispiel durch eine Verlagsveröffentlichung oder eine öffentliche Vorlesung. |
 | **archive** | Archivieren | Erlaubt die Speicherung des digitalen Objekts zum Zweck der Archivierung.<br/><br/>Auf Einrichtungen bezogen. |
+| **displaymetadata** | Anzeigen der Metadaten | Erlaubt ausschließlich die Anzeige der Metadaten im Katalog. |
+| **distribute** | (Ver)teilen | Erlaubt das nicht-öffentliche Verbreiten des digitalen Objekts, wie zum Beispiel durch die Weitergabe des digitalen Objekts im Bekanntenkreis. |
+| **download** | Herunterladen | Erlaubt das Herunterladen einer Datei auf einen Computer oder auf jeglichen anderen Datenträger. |
 | **index** | Indexieren | Erlaubt die Erzeugung und/oder das Einfügen von Metadaten in einen Index, zum Beispiel für einen Katalog.<br/><br/>Auf Einrichtungen bezogen. |
+| **lend** | Verleih | Erlaubt den Verleih des digitalen Objekts.<br/><br/>Auf Einrichtungen bezogen. |
+| **modify** | Bearbeiten | Erlaubt jede Art der Bearbeitung, Übersetzung, Umarbeitung. |
 | **move** | Übertragen der Daten | Erlaubt die Übertragung des digitalen Objekts zwischen Datenbanken, oder das interne Speichern eines digitalen Objekts, die in einer externen Datenbank des Anbieters verfügbar ist.<br/><br/>Auf Einrichtungen bezogen. |
+| **print** | Ausdrucken | Erlaubt das Ausdrucken des Werkes. |
+| **publish** | Veröffentlichen oder vorführen | Erlaubt das öffentliche Verbreiten oder Vorführen des digitalen Objekts, wie zum Beispiel durch eine Verlagsveröffentlichung oder eine öffentliche Vorlesung. |
+| **read** | „Lesen“ der Datei | Erlaubt das Öffnen und Lesen des digitalen Objekts. |
+| **reproduce** | Vervielfältigen | Erlaubt die private und öffentliche Vervielfältigung des digitalen Objekts, unabhängig davon, ob sie verbreitet wird oder nicht. |
+| **reuse** | Wiederverwenden | Erlaubt die Wiederverwendung des ganzen Werkes oder Teile des Werkes. |
+| **run** | Ausführen | Erlaubt das Ausführen des digitalen Objekts z. B. einer Anwendung. |

--- a/schema/attributes.md
+++ b/schema/attributes.md
@@ -22,19 +22,19 @@ In LibRML stehen folgende Eigenschaften zur Verfügung.
 
 | Attribut-Name | Beschreibung | Wert | Einheit&nbsp;/&nbsp;Format |
 | :------------- | :--------- | :--------- | :------------------ |
-| fromdate | Start-Datum der Einschränkung | Datum | **Format**: ISO8601 (YYYY-MM-DD) |
-| todate | End-Datum der Einschränkung | Datum | **Format**: ISO8601 (YYYY-MM-DD) |
-| maxresolution | maximal erlaubte Auflösung für den Download eines digitalen Objekts | positive integer | **Einheit**: DPI |
-| maxbitrate | maximal erlaubte Bitrate für den Download eines digitalen Objekts | positive integer | **Einheit**: Bit |
 | count | Anzahl der erlaubten Action, z. B. die Anzahl der erlaubten Ausleihen | positive integer | **Einheit**: — |
-| sessions | Anzahl der erlaubten parallelen Zugriffe auf ein digitalen Objekt | positive integer | **Einheit**: — |
-| inside | Nutzung innerhalb eines geographischen Gebiets oder innerhalb einer Institution<br/><br/> | Name | **Einheit**: — |
-| subnet | Innerhalb einer Einrichtung kann der Zugriff über ein Subnetz genauer spezifiziert werden. | IP, IP-Bereiche | **Format**: — |
-| outside | Nutzung außerhalb eines geographischen Gebiets oder außerhalb einer Institution | Name | **Einheit**: —|
-| watermarkvalue | Definition des Wasserzeichens. Das Wasserzeichen muss an einem spezifischen Ort hinterlegt sein, der hier verlinkt ist.| URI | **Format**: — |
 | duration | Dauer eines Constraints | positive integer | **Einheit**: Sekunden |
-| minage | Mindestalter für eine Action. Zum Beispiel zur Beschreibung des Jugendschutzes genutzt. | positive integer | **Einheit**: Jahre |
-| maxage | Maximalalter für eine Action. Zum Beispiel in Einrichtungen genutzt, die Kinderbücher für Erwachsene unzugänglich machen. | positive integer | **Einheit**: Jahre |
-| required | "Erforderlich" (wird bei der Erforderlichkeit von externen Verträgen benutzt) | true/false | **Format**: — |
-| parts | Teile des digitalen Objekts. | positive integer | **Einheit**: — |
+| fromdate | Start-Datum der Einschränkung | Datum | **Format**: ISO8601 (YYYY-MM-DD) |
 | groups | Gruppen, auf die eine Constraint zutrifft. | Tokenliste  | **Einheit**: — |
+| inside | Nutzung innerhalb eines geographischen Gebiets oder innerhalb einer Institution<br/><br/> | Name | **Einheit**: — |
+| maxage | Maximalalter für eine Action. Zum Beispiel in Einrichtungen genutzt, die Kinderbücher für Erwachsene unzugänglich machen. | positive integer | **Einheit**: Jahre |
+| maxbitrate | maximal erlaubte Bitrate für den Download eines digitalen Objekts | positive integer | **Einheit**: Bit |
+| maxresolution | maximal erlaubte Auflösung für den Download eines digitalen Objekts | positive integer | **Einheit**: DPI |
+| minage | Mindestalter für eine Action. Zum Beispiel zur Beschreibung des Jugendschutzes genutzt. | positive integer | **Einheit**: Jahre |
+| outside | Nutzung außerhalb eines geographischen Gebiets oder außerhalb einer Institution | Name | **Einheit**: —|
+| parts | Teile des digitalen Objekts. | positive integer | **Einheit**: — |
+| required | "Erforderlich" (wird bei der Erforderlichkeit von externen Verträgen benutzt) | true/false | **Format**: — |
+| sessions | Anzahl der erlaubten parallelen Zugriffe auf ein digitalen Objekt | positive integer | **Einheit**: — |
+| subnet | Innerhalb einer Einrichtung kann der Zugriff über ein Subnetz genauer spezifiziert werden. | IP, IP-Bereiche | **Format**: — |
+| todate | End-Datum der Einschränkung | Datum | **Format**: ISO8601 (YYYY-MM-DD) |
+| watermarkvalue | Definition des Wasserzeichens. Das Wasserzeichen muss an einem spezifischen Ort hinterlegt sein, der hier verlinkt ist.| URI | **Format**: — |

--- a/schema/constraints.md
+++ b/schema/constraints.md
@@ -30,17 +30,18 @@ In LibRML stehen folgende Einschränkung zur Verfügung.
 
 | Constraint-Name | Übersetzung | Beschreibung | Beispiel |
 | :-------------- | :--------- | :---------- |:------- |
-| parts | Teile | Einschränkung der Action auf bestimmte Teile des digitalen Objekts. | [→&nbsp;Parts](#parts) |
-| group | Gruppe | Einschränkung der Action auf bestimmte Personen oder Personengruppen. | [→&nbsp;Group](#group) |
 | age | Alter | Einschränkung der Action auf Nutzer eines bestimmten Alters. | [→&nbsp;Age](#age) |
-| location | Ort | Geographisch (ein bestimmtes Gebiet z. B. Deutschland)<br/><br/>Institutionell (eine bestimmte Einrichtung z. B. SLUB Dresden). | [→&nbsp;Location](#location) |
+| agreement | Einwilligung | Einschränkung der Action hinsichtlich eines Vertrags oder Zustimmung zu Nutzungsbedingungen. | [→&nbsp;Agreement](#agreement) |
+| concurrent | Gleichzeitig | Einschränkung der Action auf eine bestimmte Anzahl an gleichzeitigen Ausführungen, Benutzungen, … | [→&nbsp;Concurrent](#concurrent) |
+| count | Anzahl | Einschränkung der Action auf eine bestimmte Anzahl an Ausführungen, Benutzungen, … | [→&nbsp;Count](#count) |
 | date | Zeitpunkt | Einschränkung der Action ab oder bis zu einem bestimmten Zeitpunkt (Embargo). | [→&nbsp;Date](#date) |
 | duration | Dauer | Einschränkung der Action auf eine bestimmte Zeitdauer. | [→&nbsp;Duration](#duration) |
-| count | Anzahl | Einschränkung der Action auf eine bestimmte Anzahl an Ausführungen, Benutzungen, … | [→&nbsp;Count](#count) |
-| concurrent | Gleichzeitig | Einschränkung der Action auf eine bestimmte Anzahl an gleichzeitigen Ausführungen, Benutzungen, … | [→&nbsp;Concurrent](#concurrent) |
-| watermark | Wasserzeichen | Einschränkung der Action auf eine Kennzeichnung des digitalen Objekts mit einem Wasserzeichen oder einer anderen Markierung. | [→&nbsp;Watermark](#watermark) |
+| group | Gruppe | Einschränkung der Action auf bestimmte Personen oder Personengruppen. | [→&nbsp;Group](#group) |
+| location | Ort | Geographisch (ein bestimmtes Gebiet z. B. Deutschland)<br/><br/>Institutionell (eine bestimmte Einrichtung z. B. SLUB Dresden). | [→&nbsp;Location](#location) |
+| parts | Teile | Einschränkung der Action auf bestimmte Teile des digitalen Objekts. | [→&nbsp;Parts](#parts) |
 | quality | Qualität | Einschränkung der Action auf eine maximale Qualität. | [→&nbsp;Quality](#quality) |
-| agreement | Einwilligung | Einschränkung der Action hinsichtlich eines Vertrags oder Zustimmung zu Nutzungsbedingungen. | [→&nbsp;Agreement](#agreement) |
+| watermark | Wasserzeichen | Einschränkung der Action auf eine Kennzeichnung des digitalen Objekts mit einem Wasserzeichen oder einer anderen Markierung. | [→&nbsp;Watermark](#watermark) |
+
 
 ## Beispiele
 


### PR DESCRIPTION
Order tables for  [actions](https://librml.org/schema/actions.html), [constraints](https://librml.org/schema/constraints.html) and [attributes](https://librml.org/schema/attributes.html) alphabetically. 

Disadvantage: similar aspects are no longer grouped, like `fromdate` and `todate`. 