### PR TITLE
flag example as copyrighted

### DIFF
--- a/examples/copyright_openaccess.md
+++ b/examples/copyright_openaccess.md
@@ -15,7 +15,7 @@ Hinweis:
 ```xml
 <?xml version="1.0" encoding="ASCII"?>
 <libRML version="0.4" xmlns="https://librml.org/schema">
-  <item id="copyright-oa-100" tenant="https://www.slub-dresden.de/" usageguide="http://librml.org/examples/copyright_openaccess" template="LibRML Copyright - Open Access">
+  <item id="copyright-oa-100" tenant="https://www.slub-dresden.de/" usageguide="http://librml.org/examples/copyright_openaccess" template="LibRML Copyright - Open Access" copyright="true">
     <action type="displaymetadata" permission="true"/>
     <action type="index" permission="true"/>
     <action type="read" permission="true"/>
@@ -32,6 +32,7 @@ Hinweis:
   "tenant": "https://www.slub-dresden.de/",
   "usageguide": "https://librml.org/examples/copyright_openaccess",
   "template": "LibRML Copyright - Open Access",
+  "copyright": true,
   "actions": [
     {
       "type": "displaymetadata",

--- a/examples/copyright_restrictedaccess.md
+++ b/examples/copyright_restrictedaccess.md
@@ -15,7 +15,7 @@ Hinweis:
 ```xml
 <?xml version="1.0" encoding="ASCII"?>
 <libRML version="0.4" xmlns="https://librml.org/schema">
-    <item id="copyright-ra-100" tenant="https://www.slub-dresden.de/" usageguide="http://librml.org/examples/copyright_restrictedaccess" template="LibRML Copyright - Restricted Access">
+    <item id="copyright-ra-100" tenant="https://www.slub-dresden.de/" usageguide="http://librml.org/examples/copyright_restrictedaccess" template="LibRML Copyright - Restricted Access" copyright="true">
         <action type="displaymetadata" permission="true"/>
         <action type="index" permission="true"/>
         <action type="read" permission="true">
@@ -32,6 +32,7 @@ Hinweis:
   "tenant": "https://www.slub-dresden.de/",
   "usageguide": "https://librml.org/examples/copyright_restrictedaccess",
   "template": "LibRML Copyright - Restricted Access",
+  "copyright": true,
   "actions": [
     {
       "type": "displaymetadata",


### PR DESCRIPTION
I noticed that most of the examples and the templates don't make use of the `copyright` flag in the header. Probably we do not need it always, but in many cases they would be handy.
This PR fixes the most demanding cases.