### PR TITLE
restructure documentation

### DIFF
--- a/adjustments/adjustments.md
+++ b/adjustments/adjustments.md
@@ -29,16 +29,141 @@ Grundlage der Dokumentation der Anpassungen ist: [Untersuchung - LibRML - Anford
 
 ### Constraints
 
-| Bezeichnung | Beschreibung | Beispiel | Bemerkung |
-| --- | --- | --- | --- |
-| mets | Bestandteile der METS-Dateien, die zur Beschreibung der Beschränkungen in LibRML benötigt sind, werden in dem constraint `mets` beschrieben und in Attributen spezifiziert.<br/> | - | Anwendbar in Actions: {::nomarkdown}<ul><li>displaymetadata</li><li>download</li><li>index</li><li>read</li></ul>{:/} |
-| interface | Die Verfügbarkeit des Objekts an Schnittstellen wird in dem constraint `interface` beschrieben.  | - | Anwendbar in Actions: {::nomarkdown}<ul><li>publish</li></ul>{:/} |
+#### mets
+
+Bestandteile der METS-Dateien, die zur Beschreibung der Beschränkungen in LibRML benötigt sind, werden in dem constraint `mets` beschrieben und in Attributen spezifiziert.
+
+Zugehörige [Actions](/schema/actions.md):
+
+* `displaymetadata`
+* `download`
+* `index`
+* `read`
+
+#### interface
+
+Die Verfügbarkeit des Objekts an Schnittstellen wird in dem constraint `interface` beschrieben.
+
+Zugehörige [Actions](/schema/actions.md):
+
+* `publish`
 
 ### Attributes
 
-| Bezeichnung | Beschreibung | Wert | Einheit / Format | Bemerkung |
-| --- | --- | --- | --- | --- |
-| filegroups | Werte, die in dem Attribut `USE` in `<mets:fileGrp>` enthalten sind.<br/>Die Werte können zur Steuerung der Anzeige oder des Download des Objekts (Metadaten oder Mediendaten) ausgewertet werden. {::nomarkdown}<br/>Werte:<ul><li>METS-Anwendungsprofil<ul><li>DEFAULT</li><li>DOWNLOAD</li><li>FULLTEXT</li><li>THUMBS</ul></li><li>SLUB-spezifisch<ul><li>AUDIO</li><li>ORIGINAL</li><li>VIDEO</li><li>WAVEFORM</ul><li>früheres METS-Anwendungsprofil<ul><li>MIN</li><li>MAX</li></ul></ul>Anwendungsbeispiel SLUB:<ul><li>In der SLUB Dresden werden spezifische Vorgaben definiert, die von Kitodo.Presentation ausgewertet und interpretiert werden.<ul><li>THUMBS (action= read):<br/>Nur Anzeige der Thumbnails in der Listenansicht, Vorschaubilder<br/>Keine Ansicht der Derivate in der Vollansicht</li><li>DEFAULT</li><li>FULLTEXT</li><li>THUMBS (action= read):<br/>Anzeige der Thumbnails in der Listenansicht,<br/>Anzeige der Derivate DEFAULT und FULLTEXT in der Vollansicht</li><li>ORIGINAL: Anzeige</li></ul></ul>{:/} | Tokenliste | Einheit: — | Anwendbar in Constraints:<br/> `mets` |
-| fileformats | Werte, die in der METS-Datei enthalten sind oder davon abgeleitet werden, um Präsentation-Funktionen zu ermöglichen.<br/>Die Werte können zur Steuerung der Anzeige oder des Download des Objekts (Metadaten oder Mediendaten) ausgewertet werden.<br/>Werte: {::nomarkdown}<ul><li>SLUB-spezifisch:<ul><li>FULLDOWNLOAD</li><li>FULLTEXT-TXT</li><li>FULLTEXT-XML</li><li>IIIF-JSON</li><li>METS-XML</li></ul> Weitere Informationen: <ul><li>Dateien, die das digitale Objekt beschreiben:<br/>IIIF-JSON, METS-XML</li><li>Aggregierte Derivate aus METS-fileGroup:<br/>FULLDOWNLOAD<br/>mets:fileGrp[@USE="DOWNLOAD"]/mets:file[@ID="FULLDOWNLOAD"]</li><li>Abgeleitete Derivate einer METS-fileGroup:<br/>FULLTEXT-TXT, FULLTEXT-XML</li></ul>{:/} | Tokenliste | Einheit: — | Anwendbar in Constraints: <br/> `mets` |
-| OAI-PMH | Verfügbarkeit der Objekte an der OAI-Schnittstelle.<br/>Weitere Informationen: {::nomarkdown}<ul><li>internal: Bereitstellung für administrative Zwecke für das Personal innerhalb einer Einrichtung.</li><li>external: Bereitstellung ohne Einschränkung.</li></ul>{:/} | `internal`<br/>`external` | Einheit: — | Anwendbar in Constraints:<br/>`interface` |
-| IIIF | Verfügbarkeit der Objekte als IIIF-Manifest.<br/>Weitere Informationen: {::nomarkdown}<ul><li>internal Bereitstellung für administrative Zwecke für das Personal innerhalb einer Einrichtung.</li><li>external: Bereitstellung ohne Einschränkung.</li></ul>{:/} | `internal`<br/>`external` | Einheit: — | Anwendbar in Constraints:<br/>`interface` |
+#### filegroups
+
+Werte, die in dem Attribut `USE` in `<mets:fileGrp>` enthalten sind.
+
+Die Werte können zur Steuerung der Anzeige oder des Download des Objekts (Metadaten oder Mediendaten) ausgewertet werden.
+
+Werte:
+
+* METS-Anwendungsprofil
+  * DEFAULT
+  * DOWNLOAD
+  * FULLTEXT
+  * THUMBS
+* SLUB-spezifisch
+  * AUDIO
+  * ORIGINAL
+  * VIDEO
+  * WAVEFORM
+* früheres METS-Anwendungsprofil
+  * MIN
+  * MAX
+
+Anwendungsbeispiel SLUB
+
+In der SLUB Dresden werden spezifische Vorgaben definiert, die von Kitodo.Presentation ausgewertet und interpretiert werden.
+
+* "THUMBS" (action: `read`):
+  * Nur Anzeige der Thumbnails in der Listenansicht, Vorschaubilder
+  * Keine Ansicht der Derivate in der Vollansicht
+
+* "DEFAULT FULLTEXT THUMBS" (action: `read`):
+  * Anzeige der Thumbnails in der Listenansicht,
+  * Anzeige der Derivate DEFAULT und FULLTEXT in der Vollansicht
+
+ORIGINAL: Anzeige
+
+Anwendbar in Constraints:
+
+* `mets`
+
+#### fileformats
+
+Werte, die in der METS-Datei enthalten sind oder davon abgeleitet werden, um Präsentation-Funktionen zu ermöglichen.
+
+Die Werte können zur Steuerung der Anzeige oder des Download des Objekts (Metadaten oder Mediendaten) ausgewertet werden.
+
+Werte:
+
+* SLUB-spezifisch
+  * FULLDOWNLOAD
+  * FULLTEXT-TXT
+  * FULLTEXT-XML
+  * IIIF-JSON
+  * METS-XML
+
+Weitere Informationen:
+
+* Dateien, die das digitale Objekt beschreiben:
+  * IIIF-JSON
+  * METS-XML
+* Aggregierte Derivate aus METS-fileGroup:
+  * FULLDOWNLOAD
+
+  ```xml
+    mets:fileGrp[@USE="DOWNLOAD"]
+    mets:file[@ID="FULLDOWNLOAD"]
+  ```
+
+* Abgeleitete Derivate einer METS-fileGroup:
+  * FULLTEXT-TXT
+  * FULLTEXT-XML
+
+Anwendbar in Constraints:
+
+* `mets`
+
+#### OAI-PMH
+
+Verfügbarkeit der Objekte an der OAI-Schnittstelle.
+
+Werte:
+
+* `internal`
+* `external`
+
+Weitere Informationen:
+
+* `internal` =
+  Bereitstellung für administrative Zwecke für das Personal innerhalb einer Einrichtung.
+* `external` =
+  Bereitstellung ohne Einschränkung.
+
+Anwendbar in Constraints:
+
+* `interface`
+
+#### IIIF
+
+Verfügbarkeit der Objekte als IIIF-Manifest.
+
+Weitere Informationen:
+
+Werte:
+
+* internal
+* external
+
+Weitere Informationen:
+
+* "internal" =
+  Bereitstellung für administrative Zwecke für das Personal innerhalb einer Einrichtung.
+* "external" =
+  Bereitstellung ohne Einschränkung.
+
+Anwendbar in Constraints:
+
+* `interface`


### PR DESCRIPTION
This frees the documentation on the proposed LibRML extensions from the table. Further work needs to be done eventually.