### PR TITLE
standardize values of attribute required

### DIFF
--- a/adjustments/aufsicht.md
+++ b/adjustments/aufsicht.md
@@ -59,7 +59,7 @@ Umsetzung mit einem angepassten LibRML-Modell
                             <libRML:restriction type="concurrent" sessions="1"/>
                             <libRML:restriction type="location" inside="SLUB-PC-Arbeitsplätze-Lesesaal(Sammlungen)"/>
                             <libRML:restriction type="mets" filegroups="AUDIO DEFAULT VIDEO"/>
-                            <libRML:restriction type="agreement" details="Unter Aufsicht"/><!-- Unter Aufsicht -->
+                            <libRML:restriction type="agreement" required="true"/><!-- Unter Aufsicht -->
                         </libRML:action>
                     </libRML:item>
                 </libRML:libRML>


### PR DESCRIPTION
The value `details` for the constraint agreement in the example [Unter Aufsicht](https://librml.org/adjustments/aufsicht.html) is neither part of the model nor the schema, yet. Only `required` is allowed. 
Thus the value `details` is replaced by `required`. 

If the value is needed, it should be not only applied in the examples, but also documented: 
- [Erweiterungen von LibRML für Retrodigitalisate](https://librml.org/adjustments/adjustments.html)
- [Schemata](https://librml.org/schema/schemas.html)