### PR TITLE
add valid value for attribute inside

### DIFF
--- a/adjustments/persrecht.md
+++ b/adjustments/persrecht.md
@@ -22,7 +22,7 @@ Umsetzung mit dem derzeit gültigen LibRML-Modell
                         <libRML:action type="publish" permission="false"/>
                         <libRML:action type="read" permission="true">
                             <libRML:restriction type="concurrent" sessions="1"/>
-                            <libRML:restriction type="location" inside="SLUB-PC-Arbeitsplätze-Lesesaal(Sammlungen)"/>
+                            <libRML:restriction type="location" inside="SLUB-PC-Arbeitsplätze-Lesesaal-Sammlungen"/>
                             <libRML:restriction type="agreement" required="true"/><!-- Unter Aufsicht -->
                         </libRML:action>
                     </libRML:item>


### PR DESCRIPTION
`SLUB-PC-Arbeitsplätze-Lesesaal(Sammlungen)` cannot be applied with `xs:Name`. 
The value is changed to `SLUB-PC-Arbeitsplätze-Lesesaal-Sammlungen`. 