### PR TITLE
unify structure and sorting on several pages

### DIFF
--- a/_data/navi.yml
+++ b/_data/navi.yml
@@ -24,7 +24,7 @@ toc:
     path: /adjustments/
     url: adjustments.html
     subnav:
-      - title: Allgemeine Informationen
+      - title: Erweiterungen
         url: adjustments.html
       - title: Beispiele
         url: adjustments_examples.html
@@ -51,7 +51,7 @@ toc:
     path: /usage/
     url: usage.html
     subnav:
-      - title: Allgemeine Informationen
+      - title: Anwendung
         url: usage.html
       - title: Referenzen standardisierter Rechteinformationen
         url: reference_licence.html
@@ -63,35 +63,35 @@ toc:
     path: /examples/
     url: examples.html
     subnav:
-      - title: Übersicht
+      - title: Beispiele
         url: examples.html
       - title: Anzeige der Metadaten
         url: metadataonly.html
-      - title: Authentifizierung
-        url: authentification.html
-      - title: Einwilligung
-        url: agreement.html
-      - title: IP-Adressbereich
-        url: location.html
       - title: Anzeige des Objekts
         url: readonly.html
+      - title: Authentifizierung
+        url: authentification.html
       - title: Begrenztes Abspielen des Objekts
         url: duration.html
+      - title: Einwilligung
+        url: agreement.html
       - title: Embargofrist
         url: embargo.html
       - title: Gleichzeitiger Zugriff
         url: concurrent.html
-      - title: Nicht-kommerzielle Nutzung
-        url: digitization.html
+      - title: IP-Adressbereich
+        url: location.html
       - title: Copyright - Open Access
         url: copyright_openaccess.html
       - title: Copyright - Restricted Access
         url: copyright_restrictedaccess.html
+      - title: Nicht-kommerzielle Nutzung
+        url: digitization.html
   - title: Vorlagen
     path: /templates/
     url: templates.html
     subnav:
-      - title: Was sind Vorlagen?
+      - title: Vorlagen
         url: templates.html
       - title: Public Domain
         url: PDM1.html

--- a/adjustments/adjustments.md
+++ b/adjustments/adjustments.md
@@ -1,4 +1,6 @@
-# Allgemeine Informationen
+# Erweiterungen
+
+## Allgemeine Informationen
 
 In diesem Bereich werden Erweiterungen von LibRML für Retrodigitalisate im Rahmen des [DFG-Projekts](https://schutzrechte.hypotheses.org/1261) dokumentiert.
 

--- a/examples/examples.md
+++ b/examples/examples.md
@@ -1,15 +1,16 @@
-# Beispiele aus der Praxis
+# Beispiele
 
-Die folgenden Beispiele enthalten die Beschreibung ausgewählter Zugangs- und Nutzungsbeschränkungen in LibRML.
-
+Die folgenden Beispiele enthalten die Beschreibung ausgewählter Nutzungsarten (Actions) und Einschränkungen (Constraints) in LibRML.
 * [Anzeige der Metadaten](metadataonly.md)
-* [Authentifizierung](authentification.md)
-* [Einwilligung](agreement.md)
-* [Begrenztes Abspielen des Objekts](duration.md)
-* [Embargofrist](embargo.md)
-* [IP-Adressbereich](location.md)
 * [Anzeige des Objekts](readonly.md)
+* [Authentifizierung](authentification.md)
+* [Begrenztes Abspielen des Objekts](duration.md)
+* [Einwilligung](agreement.md)
+* [Embargofrist](embargo.md)
 * [Gleichzeitiger Zugriff](concurrent.md)
-* [Nicht-kommerzielle Nutzung](digitization.md)
+* [IP-Adressbereich](location.md)
+
+Die folgenden Beispiele enthalten die Beschreibung ausgewählter Anwendungsfälle in LibRML.
 * [Copyright - Open Access](copyright_openaccess.md)
 * [Copyright - Restricted Access](copyright_restrictedaccess.md)
+* [Nicht-kommerzielle Nutzung](digitization.md)

--- a/schema/concept.md
+++ b/schema/concept.md
@@ -1,4 +1,4 @@
-# Das Konzept von LibRML
+# Konzept
 
 ## Allgemeine Informationen
 

--- a/schema/constraints.md
+++ b/schema/constraints.md
@@ -44,45 +44,6 @@ In LibRML stehen folgende Einschränkungen zur Verfügung.
 
 ## Beispiele
 
-### Parts
-
-```xml
-  <action type="download" permission="true">
-    <restriction type="parts" parts="1" />
-  </action>
-```
-
-```json
-  "type": "download",
-  "permission": true,
-  "restrictions": [
-    {
-      "type": "parts",
-      "parts": "1"
-    },
-```
-
-### Group
-
-```xml
-  <action type="print" permission="true">
-    <restriction type="group" groups="registered employee" />
-  </action>
-```
-
-```json
-  "type": "print",
-  "permission": true,
-  "restrictions": [
-    {
-      "type": "group",
-      "groups": [
-        "registered",
-        "employee",
-      ]
-    },
-```
-
 ### Age
 
 ```xml
@@ -101,21 +62,57 @@ In LibRML stehen folgende Einschränkungen zur Verfügung.
     },
 ```
 
-### Location
+### Agreement
 
 ```xml
-  <action type="download" permission="true">
-    <restriction type="location" inside="library" />
+  <action type="read" permission="true">
+    <restriction type="agreement" required="true" />
   </action>
 ```
 
 ```json
-  "type": "download",
+  "type": "read",
   "permission": true,
   "restrictions": [
     {
-      "type": "location",
-      "inside": "library"
+      "type": "agreement",
+      "required": true
+    },
+```
+
+### Concurrent
+
+```xml
+  <action type="lend" permission="true">
+    <restriction type="concurrent" sessions="4" />
+  </action>
+```
+
+```json
+  "type": "lend",
+  "permission": true,
+  "restrictions": [
+    {
+      "type": "concurrent",
+      "sessions": 4
+    },
+```
+
+### Count
+
+```xml
+  <action type="print" permission="true">
+    <restriction type="count" count="10" />
+  </action>
+```
+
+```json
+  "type": "print",
+  "permission": true,
+  "restrictions": [
+    {
+      "type": "count",
+      "count": 10
     },
 ```
 
@@ -155,11 +152,11 @@ In LibRML stehen folgende Einschränkungen zur Verfügung.
     },
 ```
 
-### Count
+### Group
 
 ```xml
   <action type="print" permission="true">
-    <restriction type="count" count="10" />
+    <restriction type="group" groups="registered employee" />
   </action>
 ```
 
@@ -168,44 +165,47 @@ In LibRML stehen folgende Einschränkungen zur Verfügung.
   "permission": true,
   "restrictions": [
     {
-      "type": "count",
-      "count": 10
+      "type": "group",
+      "groups": [
+        "registered",
+        "employee",
+      ]
     },
 ```
 
-### Concurrent
+### Location
 
 ```xml
-  <action type="lend" permission="true">
-    <restriction type="concurrent" sessions="4" />
+  <action type="download" permission="true">
+    <restriction type="location" inside="library" />
   </action>
 ```
 
 ```json
-  "type": "lend",
+  "type": "download",
   "permission": true,
   "restrictions": [
     {
-      "type": "concurrent",
-      "sessions": 4
+      "type": "location",
+      "inside": "library"
     },
 ```
 
-### Watermark
+### Parts
 
 ```xml
-  <action type="distribute" permission="true">
-    <restriction type="watermark" watermarkvalue="https://domain/watermark.png" />
+  <action type="download" permission="true">
+    <restriction type="parts" parts="1" />
   </action>
 ```
 
 ```json
-  "type": "distribute",
+  "type": "download",
   "permission": true,
   "restrictions": [
     {
-      "type": "watermark",
-      "watermarkvalue": "https://domain/watermark.png"
+      "type": "parts",
+      "parts": "1"
     },
 ```
 
@@ -227,20 +227,20 @@ In LibRML stehen folgende Einschränkungen zur Verfügung.
     },
 ```
 
-### Agreement
+### Watermark
 
 ```xml
-  <action type="read" permission="true">
-    <restriction type="agreement" required="true" />
+  <action type="distribute" permission="true">
+    <restriction type="watermark" watermarkvalue="https://domain/watermark.png" />
   </action>
 ```
 
 ```json
-  "type": "read",
+  "type": "distribute",
   "permission": true,
   "restrictions": [
     {
-      "type": "agreement",
-      "required": true
+      "type": "watermark",
+      "watermarkvalue": "https://domain/watermark.png"
     },
 ```

--- a/templates/templates.md
+++ b/templates/templates.md
@@ -1,8 +1,4 @@
-# Was sind Vorlagen?
-
-Vorlagen (sogenannte ''Templates''') werden bereitgestellt, um die Erfassung von Nutzungsrechten in LibRML zu vereinfachen. Diese Vorlagen können in einem projektierten Eingabeassistenten ausgewählt werden, wodruch sich die Erfassung von einzelnen [**Actions**](../schema/actions.md) und [**Constraints**](../schema/constraints.md) erübrigt. Anschließend können einzelne Beschränkungen angepasst oder hinzugefügt werden.
-
-## Vorlagen für gebräuchliche Lizenzen
+# Vorlagen
 
 | Name / Link | Beschreibung | Typ |
 | :----- | :---- | :---: |

--- a/usage/usage.md
+++ b/usage/usage.md
@@ -1,4 +1,6 @@
-# Allgemeine Informationen
+# Anwendung
+
+## Allgemeine Informationen
 
 LibRML kann den jeweiligen Anforderungen entsprechend angewendet werden. Es können bestehende Empfehlungen und Standards berücksichtigt werden, um die Anwendung zu vereinfachen. Im Folgenden werden drei Möglichkeiten vorgestellt.
 
@@ -6,19 +8,19 @@ LibRML kann den jeweiligen Anforderungen entsprechend angewendet werden. Es kön
 1. Referenzen von standardisierter Zugriffs- und Nutzungsbeschränkungen
 1. Eingebettetes spezifischen LibRML-Codes in Metadatendateien
 
-# Referenzen standardisierter Lizenz- und Rechtehinweise
+## Referenzen standardisierter Lizenz- und Rechtehinweise
 
 Standardisierte Lizenz- und Rechtehinweise, die in spezifischen Elementen des jeweils angewendeten Metadatenstandards eingetragen sind, werden von einem System (Präsentation, Repositorium, Rechtemanagementsystem, …) ausgewertet und in LibRML übertragen. Dadurch wird eine redundante Erfassung der Rechteinformationen vermieden.
 
 Siehe [Referenzen standardisierter Rechteinformationen](reference_licence)
 
-# Referenzen standardisierter Zugriffs- und Nutzungsbeschränkungen
+## Referenzen standardisierter Zugriffs- und Nutzungsbeschränkungen
 
 Referenzen (URI) auf Zugriffs- und Nutzungsbeschränkungen, die in den Metadatenstandards in spezifischen Elementen eingetragen sind, werden von einem System (Präsentation, Repositorium, Rechtemanagementsystem, …) ausgewertet und in LibRML übertragen. Dadurch wird die Erfassung der Beschränkungen erleichtert. Einige Systeme sind unter Umständen noch nicht in der Lage, reines LibRML auszugeben.
 
 Siehe [Referenzen standardisierter Beschränkungen](reference_usage)
 
-# Eingebettetes LibRML in der Metadatendatei
+## Eingebettetes LibRML in der Metadatendatei
 
 Zugriffs- und Nutzungsbeschränkungen werden mittels LibRML in eine Metadatendatei eingebettet und von einem System (Präsentation, Repositorium, Rechtemanagementsystem, …) ausgewertet.
 


### PR DESCRIPTION
- Standardize headings and heading levels across pages and the navigation tree.
- Reorder examples alphabetically in both the page content and the structure tree.
- Update the alphabetical sorting of the examples on the page [constraints](https://librml.org/schema/constraints.html).