### PR TITLE
Clarify index and displaymetadata

### DIFF
--- a/adjustments/adjustments_elements_existing.md
+++ b/adjustments/adjustments_elements_existing.md
@@ -36,8 +36,7 @@ Ziel ist unter anderem die Erstellung eines Anwendungsprofils für Retrodigitali
 * **index**
   * **Relevanz:** Ja
   * **Bemerkung:**
-    * Die Metadaten der digitalen Objekte können gesucht und angezeigt werden.
-    * Wenn die Metadaten nicht indexiert werden dürfen, ist eine Aufnahme des digitalen Objekts in die Digitalen Sammlungen nicht notwendig.
+    * Volltexte (und verwandte Derivate) der digitalen Objekte werden indexiert und können durchsucht werden.
   * **Beispiele:**
     * [Eingeschränkter Zugang - Arbeitsplätze Mediathek - Unter Aufsicht](/adjustments/aufsicht.md)
     * [Künstlerbücher](/adjustments/kuenstlerbuecher.md)

--- a/adjustments/ansicht.md
+++ b/adjustments/ansicht.md
@@ -45,9 +45,7 @@ Umsetzung mit einem angepassten LibRML-Modell
                         <libRML:action type="publish" permission="true">
                             <libRML:restriction type="interface" OAI-PMH="internal"/>
                         </libRML:action>
-                        <libRML:action type="read" permission="true">
-                            <libRML:restriction type="mets" filegroups="AUDIO DEFAULT VIDEO"/>
-                        </libRML:action>
+                        <libRML:action type="read" permission="true"/>
                     </libRML:item>
                 </libRML:libRML>
             </mets:mdWrap>

--- a/adjustments/ansicht.md
+++ b/adjustments/ansicht.md
@@ -39,13 +39,9 @@ Umsetzung mit einem angepassten LibRML-Modell
             <mets:mdWrap MDTYPE="OTHER" MIMETYPE="text/xml" OTHERMDTYPE="LibRML">
                 <libRML:libRML xmlns:libRML="http://librml.org/schema">
                     <libRML:item usageguide="https://nutzungshinweis.slub-dresden.de/en-ma/1.0/">
-                        <libRML:action type="displaymetadata" permission="true">
-                            <libRML:restriction type="mets" sections="amdSec dmdSec structMap"/>
-                        </libRML:action>
+                        <libRML:action type="displaymetadata" permission="true"/>
                         <libRML:action type="download" permission="false"/>
-                        <libRML:action type="index" permission="true">
-                            <libRML:restriction type="mets" sections="dmdSec"/>
-                        </libRML:action>
+                        <libRML:action type="index" permission="true"/>
                         <libRML:action type="publish" permission="true">
                             <libRML:restriction type="interface" OAI-PMH="internal"/>
                         </libRML:action>

--- a/adjustments/aufsicht.md
+++ b/adjustments/aufsicht.md
@@ -16,7 +16,11 @@ Umsetzung mit dem derzeit gültigen LibRML-Modell
                     <libRML:item usageguide="https://nutzungshinweis.slub-dresden.de/ez-am-ua/1.0/">
                         <libRML:action type="displaymetadata" permission="true"/>
                         <libRML:action type="download" permission="false"/>
-                        <libRML:action type="index" permission="true"/>
+                        <libRML:action type="index" permission="true">
+                            <libRML:restriction type="concurrent" sessions="1"/>
+                            <libRML:restriction type="location" inside="SLUB-PC-Arbeitsplätze-Lesesaal(Sammlungen)"/>
+                            <libRML:restriction type="agreement" required="true"/><!-- Unter Aufsicht -->
+                        </libRML:action>
                         <libRML:action type="publish" permission="false"/>
                         <libRML:action type="read" permission="true">
                             <libRML:restriction type="concurrent" sessions="1"/>
@@ -43,12 +47,13 @@ Umsetzung mit einem angepassten LibRML-Modell
             <mets:mdWrap MDTYPE="OTHER" MIMETYPE="text/xml" OTHERMDTYPE="LibRML">
                 <libRML:libRML xmlns:libRML="http://librml.org/schema">
                     <libRML:item usageguide="https://nutzungshinweis.slub-dresden.de/ez-am-ua/1.0/">
-                        <libRML:action type="displaymetadata" permission="true">
-                            <libRML:restriction type="mets" sections="amdSec dmdSec structMap"/>
-                        </libRML:action>
+                        <libRML:action type="displaymetadata" permission="true"/>
                         <libRML:action type="download" permission="false"/>
                         <libRML:action type="index" permission="true">
-                            <libRML:restriction type="mets" sections="dmdSec"/>
+                            <libRML:restriction type="concurrent" sessions="1"/>
+                            <libRML:restriction type="location" inside="SLUB-PC-Arbeitsplätze-Lesesaal(Sammlungen)"/>
+                            <libRML:restriction type="agreement" required="true"/><!-- Unter Aufsicht -->
+                        </libRML:action>
                         </libRML:action>
                         <libRML:action type="publish" permission="true">
                             <libRML:restriction type="interface" OAI-PMH="internal"/>

--- a/adjustments/grafik.md
+++ b/adjustments/grafik.md
@@ -39,15 +39,12 @@ Umsetzung mit einem angepassten LibRML-Modell
             <mets:mdWrap MDTYPE="OTHER" MIMETYPE="text/xml" OTHERMDTYPE="LibRML">
                 <libRML:libRML xmlns:libRML="http://librml.org/schema">
                     <libRML:item usageguide="https://nutzungshinweis.slub-dresden.de/ge-re/1.0/">
-                        <libRML:action type="displaymetadata" permission="true">
-                            <libRML:restriction type="mets" sections="amdSec dmdSec structMap"/>
-                        </libRML:action>
+                        <libRML:action type="displaymetadata" permission="true"/>
                         <libRML:action type="download" permission="true">
                             <libRML:restriction type="mets" filegroups="DEFAULT DOWNLOAD"/>
                             <libRML:restriction type="mets" fileformats="FULLTEXT-TXT FULLTEXT-XML IIIF-JSON"/>
                         </libRML:action>
                         <libRML:action type="index" permission="true">
-                            <libRML:restriction type="mets" sections="dmdSec"/>
                             <libRML:restriction type="mets" filegroups="FULLTEXT"/>
                         </libRML:action>
                         <libRML:action type="publish" permission="true">

--- a/adjustments/kuenstlerbuecher.md
+++ b/adjustments/kuenstlerbuecher.md
@@ -63,7 +63,6 @@ Umsetzung mit einem angepassten LibRML-Modell
                         <libRML:action type="read" permission="true">
                             <libRML:restriction type="concurrent" sessions="1"/>
                             <libRML:restriction type="location" inside="SLUB-PC-Arbeitsplätze"/>
-                            <libRML:restriction type="mets" filegroups="DEFAULT FULLTEXT THUMBS"/>
                         </libRML:action>
                     </libRML:item>
                 </libRML:libRML>

--- a/adjustments/kuenstlerbuecher.md
+++ b/adjustments/kuenstlerbuecher.md
@@ -18,7 +18,10 @@ Umsetzung mit dem derzeit gültigen LibRML-Modell
                         <libRML:action type="download" permission="true">
                             <libRML:restriction type="parts" percentage="10"/>
                         </libRML:action>
-                        <libRML:action type="index" permission="true"/>
+                        <libRML:action type="index" permission="true">
+                            <libRML:restriction type="concurrent" sessions="1"/>
+                            <libRML:restriction type="location" inside="SLUB-PC-Arbeitsplätze"/>
+                        </libRML:action>
                         <libRML:action type="publish" permission="false"/>
                         <libRML:action type="read" permission="true">
                             <libRML:restriction type="concurrent" sessions="1"/>
@@ -44,17 +47,15 @@ Umsetzung mit einem angepassten LibRML-Modell
             <mets:mdWrap MDTYPE="OTHER" MIMETYPE="text/xml" OTHERMDTYPE="LibRML">
                 <libRML:libRML xmlns:libRML="http://librml.org/schema">
                     <libRML:item usageguide="https://nutzungshinweis.slub-dresden.de/kr-bu/1.0/">
-                        <libRML:action type="displaymetadata" permission="true">
-                            <libRML:restriction type="mets" sections="amdSec dmdSec structMap"/>
-                        </libRML:action>
+                        <libRML:action type="displaymetadata" permission="true"/>
                         <libRML:action type="download" permission="true">
                             <libRML:restriction type="mets" filegroups="DOWNLOAD"/>
                             <libRML:restriction type="mets" fileformats="FULLDOWNLOAD-PDF FULLTEXT-TXT FULLTEXT-XML IIIF-JSON"/>
                             <libRML:restriction type="parts" percentage="10"/>
                         </libRML:action>
                         <libRML:action type="index" permission="true">
-                            <libRML:restriction type="mets" sections="dmdSec"/>
-                            <libRML:restriction type="mets" filegroups="FULLTEXT"/>
+                            <libRML:restriction type="concurrent" sessions="1"/>
+                            <libRML:restriction type="location" inside="SLUB-PC-Arbeitsplätze"/>
                         </libRML:action>
                         <libRML:action type="publish" permission="true">
                             <libRML:restriction type="interface" OAI-PMH="internal"/>

--- a/adjustments/mediathek.md
+++ b/adjustments/mediathek.md
@@ -55,7 +55,6 @@ Umsetzung mit einem angepassten LibRML-Modell
                         <libRML:action type="read" permission="true">
                             <libRML:restriction type="concurrent" sessions="1"/>
                             <libRML:restriction type="location" inside="SLUB-PC-Arbeitsplätze-Mediathek"/>
-                            <libRML:restriction type="mets" filegroups="AUDIO DEFAULT VIDEO"/>
                         </libRML:action>
                     </libRML:item>
                 </libRML:libRML>

--- a/adjustments/mediathek.md
+++ b/adjustments/mediathek.md
@@ -16,7 +16,10 @@ Umsetzung mit dem derzeit gültigen LibRML-Modell
                     <libRML:item usageguide="https://nutzungshinweis.slub-dresden.de/ez-am/1.0/">
                         <libRML:action type="displaymetadata" permission="true"/>
                         <libRML:action type="download" permission="false"/>
-                        <libRML:action type="index" permission="true"/>
+                        <libRML:action type="index" permission="true">
+                            <libRML:restriction type="concurrent" sessions="1"/>
+                            <libRML:restriction type="location" inside="SLUB-PC-Arbeitsplätze-Mediathek"/>
+                        </libRML:action>
                         <libRML:action type="publish" permission="false"/>
                         <libRML:action type="read" permission="true">
                             <libRML:restriction type="concurrent" sessions="1"/>
@@ -44,7 +47,10 @@ Umsetzung mit einem angepassten LibRML-Modell
                     <libRML:item usageguide="https://nutzungshinweis.slub-dresden.de/ez-am/1.0/">
                         <libRML:action type="displaymetadata" permission="true"/>
                         <libRML:action type="download" permission="false"/>
-                        <libRML:action type="index" permission="true"/>
+                        <libRML:action type="index" permission="true">
+                            <libRML:restriction type="concurrent" sessions="1"/>
+                            <libRML:restriction type="location" inside="SLUB-PC-Arbeitsplätze-Mediathek"/>
+                        </libRML:action>
                         <libRML:action type="publish" permission="false"/>
                         <libRML:action type="read" permission="true">
                             <libRML:restriction type="concurrent" sessions="1"/>

--- a/adjustments/persrecht.md
+++ b/adjustments/persrecht.md
@@ -16,8 +16,12 @@ Umsetzung mit dem derzeit gültigen LibRML-Modell
                     <libRML:item usageguide="https://nutzungshinweis.slub-dresden.de/ez-am-pr/1.0/">
                         <libRML:action type="displaymetadata" permission="true"/>
                         <libRML:action type="download" permission="false"/>
-                        <libRML:action type="index" permission="true"/>
                         <libRML:action type="publish" permission="false"/>
+                        <libRML:action type="index" permission="true">
+                            <libRML:restriction type="concurrent" sessions="1"/>
+                            <libRML:restriction type="location" inside="SLUB-PC-Arbeitsplätze-Lesesaal-Sammlungen"/>
+                            <libRML:restriction type="agreement" required="true"/><!-- Unter Aufsicht -->
+                        </libRML:action>
                         <libRML:action type="read" permission="true">
                             <libRML:restriction type="concurrent" sessions="1"/>
                             <libRML:restriction type="location" inside="SLUB-PC-Arbeitsplätze-Lesesaal-Sammlungen"/>
@@ -43,12 +47,13 @@ Umsetzung mit einem angepassten LibRML-Modell
             <mets:mdWrap MDTYPE="OTHER" MIMETYPE="text/xml" OTHERMDTYPE="LibRML">
                 <libRML:libRML xmlns:libRML="http://librml.org/schema">
                     <libRML:item usageguide="https://nutzungshinweis.slub-dresden.de/ez-am-pr/1.0/">
-                        <libRML:action type="displaymetadata" permission="true">
-                            <libRML:restriction type="mets" sections="amdSec dmdSec structMap"/>
-                        </libRML:action>
+                        <libRML:action type="displaymetadata" permission="true"/>
                         <libRML:action type="download" permission="false"/>
                         <libRML:action type="index" permission="true">
-                            <libRML:restriction type="mets" sections="dmdSec"/>
+                            <libRML:restriction type="concurrent" sessions="1"/>
+                            <libRML:restriction type="location" inside="SLUB-PC-Arbeitsplätze-Lesesaal(Sammlungen)"/>
+                            <libRML:restriction type="agreement" required="true"/><!-- Unter Aufsicht -->
+                        </libRML:action>
                         </libRML:action>
                         <libRML:action type="publish" permission="true">
                             <libRML:restriction type="interface" OAI-PMH="internal"/>

--- a/adjustments/persrecht.md
+++ b/adjustments/persrecht.md
@@ -61,7 +61,6 @@ Umsetzung mit einem angepassten LibRML-Modell
                         <libRML:action type="read" permission="true">
                             <libRML:restriction type="concurrent" sessions="1"/>
                             <libRML:restriction type="location" inside="SLUB-PC-Arbeitsplätze-Lesesaal(Sammlungen)"/>
-                            <libRML:restriction type="mets" filegroups="AUDIO DEFAULT VIDEO"/>
                             <libRML:restriction type="agreement" required="true"/><!-- Unter Aufsicht -->
                         </libRML:action>
                     </libRML:item>

--- a/adjustments/saechsischezeitung.md
+++ b/adjustments/saechsischezeitung.md
@@ -49,7 +49,6 @@ Umsetzung mit einem angepassten LibRML-Modell
                     <libRML:item usageguide="https://nutzungshinweis.slub-dresden.de/sc-zt/1.0/">
                         <libRML:action type="displaymetadata" permission="true">
                             <libRML:restriction type="group" groups="SLUB-Nutzende"/>
-                            <libRML:restriction type="mets" sections="amdSec dmdSec structMap"/>
                         </libRML:action>
                         <libRML:action type="download" permission="true">
                             <libRML:restriction type="group" groups="SLUB-Nutzende"/>
@@ -58,14 +57,12 @@ Umsetzung mit einem angepassten LibRML-Modell
                         </libRML:action>
                         <libRML:action type="index" permission="true">
                             <libRML:restriction type="group" groups="SLUB-Nutzende"/>
-                            <libRML:restriction type="mets" filegroups="FULLTEXT"/>
                         </libRML:action>
                         <libRML:action type="publish" permission="true">
                             <libRML:restriction type="interface" OAI-PMH="internal"/>
                         </libRML:action>
                         <libRML:action type="read" permission="true">
                             <libRML:restriction type="group" groups="SLUB-Nutzende"/>
-                            <libRML:restriction type="mets" filegroups="DEFAULT FULLTEXT THUMBS"/>
                         </libRML:action>
                     </libRML:item>
                 </libRML:libRML>

--- a/adjustments/saechsischezeitung.md
+++ b/adjustments/saechsischezeitung.md
@@ -20,7 +20,9 @@ Umsetzung mit dem derzeit gültigen LibRML-Modell
                         <libRML:action type="download" permission="true">
                             <libRML:restriction type="group" groups="SLUB-Nutzende"/>
                         </libRML:action>
-                        <libRML:action type="index" permission="true"/>
+                        <libRML:action type="index" permission="true">
+                            <libRML:restriction type="group" groups="SLUB-Nutzende"/>
+                        </libRML:action>
                         <libRML:action type="publish" permission="false"/>
                         <libRML:action type="read" permission="true">
                             <libRML:restriction type="group" groups="SLUB-Nutzende"/>

--- a/examples/agreement.md
+++ b/examples/agreement.md
@@ -5,11 +5,11 @@ Zugang und Nutzung nur nach Einwilligung, zum Beispiel durch Abschluss eines Nut
 **Uneingeschränkte Nutzungsarten**:
 
 - displaymetadata (Anzeigen der Metadaten)
-- index (Indexieren)
 - archive (Archivieren)
 
 **Eingeschränkte Nutzungsarten**:
 
+- index (Indexnutzung)
 - read (Lesen)
 - download (Herunterladen)
 - print (Ausdrucken)
@@ -29,12 +29,14 @@ Zugang und Nutzung nur nach Einwilligung, zum Beispiel durch Abschluss eines Nut
 <libRML version="0.4" xmlns="http://librml.org/schema">
   <item commercialuse="true" id="agreement-DE-447" template="Agreement" tenant="https://www.slub-dresden.de/">
     <action type="displaymetadata" permission="true"/>
-    <action type="index" permission="true"/>
     <action type="archive" permission="true"/>
     <action type="read" permission="true">
       <restriction type="agreement" required="true"/>
     </action>
     <action type="download" permission="true">
+      <restriction type="agreement" required="true"/>
+    </action>
+    <action type="index" permission="true">
       <restriction type="agreement" required="true"/>
     </action>
     <action type="print" permission="true">
@@ -74,12 +76,18 @@ Zugang und Nutzung nur nach Einwilligung, zum Beispiel durch Abschluss eines Nut
       "permission": true
     },
     {
-      "type": "index",
+      "type": "archive",
       "permission": true
     },
     {
-      "type": "archive",
-      "permission": true
+      "type": "index",
+      "permission": true,
+      "restrictions": [
+        {
+          "type": "agreement",
+          "required": true
+        }
+      ]
     },
     {
       "type": "read",

--- a/examples/authentification.md
+++ b/examples/authentification.md
@@ -5,11 +5,11 @@ Zugang und Nutzung nur nach Authentifizierung. In LibRML wird dies durch Zugehö
 **Uneingeschränkte Nutzungsarten**:
 
 - displaymetadata (Anzeigen der Metadaten)
-- index (Indexieren)
 - archive (Archivieren)
 
 **Eingeschränkte Nutzungsarten**:
 
+- index (Indexnutzung)
 - read (Lesen)
 - download (Herunterladen)
 - print (Ausdrucken)
@@ -23,8 +23,10 @@ Zugang und Nutzung nur nach Authentifizierung. In LibRML wird dies durch Zugehö
 <libRML version="0.4" xmlns="http://librml.org/schema">
   <item commercialuse="true" id="auth-DE-442" template="Authentification" tenant="https://www.slub-dresden.de/">
     <action type="displaymetadata" permission="true"/>
-    <action type="index" permission="true"/>
     <action type="archive" permission="true"/>
+    <action type="index" permission="true">
+      <restriction type="group" groups="registered"/>
+    </action>
     <action type="read" permission="true">
       <restriction type="group" groups="registered"/>
     </action>
@@ -50,12 +52,20 @@ Zugang und Nutzung nur nach Authentifizierung. In LibRML wird dies durch Zugehö
       "permission": true
     },
     {
-      "type": "index",
+      "type": "archive",
       "permission": true
     },
     {
-      "type": "archive",
-      "permission": true
+      "type": "index",
+      "permission": true,
+      "restrictions": [
+        {
+          "type": "group",
+          "groups": [
+            "registered"
+          ]
+        }
+      ]
     },
     {
       "type": "read",

--- a/examples/concurrent.md
+++ b/examples/concurrent.md
@@ -5,11 +5,11 @@ Zugang und Nutzung ist auf eine bestimmte Menge gleichzeitiger Zugriffe beschrä
 **Uneingeschränkte Nutzungsarten**:
 
 - displaymetadata (Anzeigen der Metadaten)
-- index (Indexieren)
 - archive (Archivieren)
 
 **Eingeschränkte Nutzungsarten**:
 
+- index (Indexnutzung)
 - read (Lesen)
 - download (Herunterladen)
 - print (Ausdrucken)
@@ -23,8 +23,10 @@ Zugang und Nutzung ist auf eine bestimmte Menge gleichzeitiger Zugriffe beschrä
 <libRML version="0.4" xmlns="http://librml.org/schema">
   <item commercialuse="true" id="concuracc-440" template="ConcurrentAccess" tenant="https://www.slub-dresden.de/">
     <action type="displaymetadata" permission="true"/>
-    <action type="index" permission="true"/>
     <action type="archive" permission="true"/>
+    <action type="index" permission="true">
+      <restriction type="concurrent" sessions="5"/>
+    </action>
     <action type="read" permission="true">
       <restriction type="concurrent" sessions="5"/>
     </action>
@@ -50,12 +52,18 @@ Zugang und Nutzung ist auf eine bestimmte Menge gleichzeitiger Zugriffe beschrä
       "permission": true
     },
     {
-      "type": "index",
+      "type": "archive",
       "permission": true
     },
     {
-      "type": "archive",
-      "permission": true
+      "type": "index",
+      "permission": true,
+      "restrictions": [
+        {
+          "type": "concurrent",
+          "sessions": 5
+        }
+      ]
     },
     {
       "type": "read",

--- a/examples/digitization.md
+++ b/examples/digitization.md
@@ -5,7 +5,7 @@ Ein urheberrechtsbehaftetes digitales Objekt der [SLUB Dresden](https://www.slub
 **Uneingeschränkte Nutzungsarten**:
 
 - displaymetadata (Anzeigen der Metadaten)
-- index (Indexieren)
+- index (Indexnutzung)
 - read (Lesen)
 - archive (Archivieren)
 - distribute ((Ver)teilen)

--- a/examples/duration.md
+++ b/examples/duration.md
@@ -5,7 +5,6 @@ Die Wiedergabe der Audio-/Videodatei ist ausschnittsweise erlaubt, jedoch maxima
 **Uneingeschränkte Nutzungsarten**:
 
 - displaymetadata (Anzeigen der Metadaten)
-- index (Indexieren)
 - archive (Archivieren)
 
 **Eingeschränkte Nutzungsarten**:
@@ -18,7 +17,6 @@ Die Wiedergabe der Audio-/Videodatei ist ausschnittsweise erlaubt, jedoch maxima
 <libRML version="0.4" xmlns="http://librml.org/schema">
   <item id="readonly-449" template="Read only" tenant="https://www.slub-dresden.de/">
     <action type="displaymetadata" permission="true"/>
-    <action type="index" permission="true"/>
     <action type="archive" permission="true"/>
     <action type="read" permission="true">
       <restriction type="duration" percentage="10"/>
@@ -40,10 +38,6 @@ Die Wiedergabe der Audio-/Videodatei ist ausschnittsweise erlaubt, jedoch maxima
   "actions": [
     {
       "type": "displaymetadata",
-      "permission": true
-    },
-    {
-      "type": "index",
       "permission": true
     },
     {

--- a/examples/embargo.md
+++ b/examples/embargo.md
@@ -7,7 +7,7 @@ Ab dem 1. Januar 2029 ist der Zugang dann uneingeschränkt möglich.
 **Uneingeschränkte Nutzungsarten**:
 
 - displaymetadata (Anzeigen der Metadaten)
-- index (Indexieren)
+- index (Indexnutzung)
 - archive (Archivieren)
 
 **Eingeschränkte Nutzungsarten**:

--- a/examples/location.md
+++ b/examples/location.md
@@ -5,11 +5,11 @@ Zugang und Nutzung nur innerhalb eines IP-Adressbereichs, wie zum Beispiel Campu
 **Uneingeschränkte Nutzungsarten**:
 
 - displaymetadata (Anzeigen der Metadaten)
-- index (Indexieren)
 - archive (Archivieren)
 
 **Eingeschränkte Nutzungsarten**:
 
+- index (Indexnutzung)
 - read (Lesen)
 - download (Ausdrucken)
 - print (Herunterladen)
@@ -23,8 +23,10 @@ Zugang und Nutzung nur innerhalb eines IP-Adressbereichs, wie zum Beispiel Campu
 <libRML version="0.4" xmlns="http://librml.org/schema">
   <item commercialuse="false" id="iprestricted-444" template="IP" tenant="https://www.slub-dresden.de/">
     <action type="displaymetadata" permission="true"/>
-    <action type="index" permission="true"/>
     <action type="archive" permission="true"/>
+    <action type="index" permission="true">
+      <restriction type="location" subnet="192.168.10.0/24"/>
+    </action>
     <action type="read" permission="true">
       <restriction type="location" subnet="192.168.10.0/24"/>
     </action>

--- a/examples/metadataonly.md
+++ b/examples/metadataonly.md
@@ -5,7 +5,6 @@ Zugang nur zu Metadaten, eine weitere Nutzung (z.B. Ansicht und Download) des di
 **Uneingeschränkte Nutzungsarten**:
 
 - displaymetadata (Anzeigen der Metadaten)
-- index (Indexieren)
 
 **Eingeschränkte Nutzungsarten**:
 
@@ -16,7 +15,6 @@ Zugang nur zu Metadaten, eine weitere Nutzung (z.B. Ansicht und Download) des di
 <libRML version="0.4" xmlns="http://librml.org/schema">
   <item id="metaonly-441" template="Metadata access only" tenant="https://www.slub-dresden.de/">
     <action type="displaymetadata" permission="true"/>
-    <action type="index" permission="true"/>
   </item>
 </libRML>
 ```
@@ -29,10 +27,6 @@ Zugang nur zu Metadaten, eine weitere Nutzung (z.B. Ansicht und Download) des di
   "actions": [
     {
       "type": "displaymetadata",
-      "permission": true
-    },
-    {
-      "type": "index",
       "permission": true
     }
   ]

--- a/examples/readonly.md
+++ b/examples/readonly.md
@@ -5,7 +5,6 @@ Zugang zum Objekt zur Ansicht ohne weitere Nutzungsmöglichkeiten, wie Speichern
 **Uneingeschränkte Nutzungsarten**:
 
 - displaymetadata (Anzeigen der Metadaten)
-- index (Indexieren)
 - read (Lesen)
 - archive (Archivieren)
 
@@ -18,7 +17,6 @@ Zugang zum Objekt zur Ansicht ohne weitere Nutzungsmöglichkeiten, wie Speichern
 <libRML version="0.4" xmlns="http://librml.org/schema">
   <item id="readonly-449" template="Read only" tenant="https://www.slub-dresden.de/">
     <action type="displaymetadata" permission="true"/>
-    <action type="index" permission="true"/>
     <action type="read" permission="true"/>
     <action type="archive" permission="true"/>
   </item>
@@ -33,10 +31,6 @@ Zugang zum Objekt zur Ansicht ohne weitere Nutzungsmöglichkeiten, wie Speichern
   "actions": [
     {
       "type": "displaymetadata",
-      "permission": true
-    },
-    {
-      "type": "index",
       "permission": true
     },
     {

--- a/schema/actions.md
+++ b/schema/actions.md
@@ -33,10 +33,10 @@ In LibRML stehen die folgenden Nutzungsarten zur Verfügung. Es wird zwischen te
 | Action-Name | Übersetzung | Beschreibung |
 | :---------- | :--------- | :----------- |
 | **archive** | Archivieren | Erlaubt die Speicherung des digitalen Objekts zum Zweck der Archivierung.<br/> _einrichtungsinterne Nutzungsart_ |
-| **displaymetadata** | Anzeigen der Metadaten | Erlaubt ausschließlich die Anzeige der Metadaten im Katalog. |
+| **displaymetadata** | Anzeigen der Metadaten | Regelt das Auffinden des Objektes und die Anzeige dessen Metadaten im Katalog. |
 | **distribute** | (Ver)teilen | Erlaubt das nicht-öffentliche Verbreiten des digitalen Objekts, wie zum Beispiel durch die Weitergabe des digitalen Objekts im Bekanntenkreis.<br/> _technisch nicht durchsetzbar_ |
 | **download** | Herunterladen | Erlaubt das Herunterladen einer Datei auf einen Computer oder auf jeglichen anderen Datenträger. |
-| **index** | Indexieren | Erlaubt die Erzeugung und/oder das Einfügen von Metadaten in einen Index, zum Beispiel für einen Katalog.<br/> _einrichtungsinterne Nutzungsart_ |
+| **index** | Indexnutzung | Erlaubt die Erzeugung und das Durchsuchen von Volltexten.<br/> _einrichtungsinterne Nutzungsart_ |
 | **lend** | Verleih | Erlaubt den Verleih des digitalen Objekts.<br/> _einrichtungsinterne Nutzungsart_ |
 | **modify** | Bearbeiten | Erlaubt jede Art der Bearbeitung, Übersetzung, Umarbeitung.<br/> _technisch nicht durchsetzbar_ |
 | **move** | Übertragen der Daten | Erlaubt die Übertragung des digitalen Objekts zwischen Datenbanken, oder das interne Speichern eines digitalen Objekts, die in einer externen Datenbank des Anbieters verfügbar ist.<br/> _einrichtungsinterne Nutzungsart_ |

--- a/schema/dependencies.md
+++ b/schema/dependencies.md
@@ -6,13 +6,13 @@ In der folgendenden Tabelle sind die erlaubten Kombinationen von Einschränkunge
 
 | Constraint | Attributes | Actions |
 | :--------- | :--------- | :--------- |
-| age | maxage <br> minage | alle außer `archive` `displaymetadata` `index` `move` |
-| agreement | required | alle außer `displaymetadata` `index` |
+| age | maxage <br> minage | alle außer `archive` `displaymetadata` `move` |
+| agreement | required | alle außer `displaymetadata` |
 | concurrent | sessions | nur `lend` `read` `run` |
 | count | count | nur `download` `lend` `print` `read` `reproduce` `run` |
 | date | fromdate <br> todate | alle |
 | duration | maxduration <br> percentage | nur `lend` `read` `run` |
-| group | groups | alle außer `archive` `displaymetadata` `index` `move` |
+| group | groups | alle außer `archive` `displaymetadata` `move` |
 | location | inside <br> outside <br> subnet | alle |
 | parts | percentage | alle außer `displaymetadata` `index` |
 | quality | maxbitrate <br> maxresolution | alle außer `archive` `displaymetadata` `index` `move` |

--- a/usage/embedded.md
+++ b/usage/embedded.md
@@ -54,8 +54,10 @@ In dem folgenden Beispiel wird [Zugang nur innerhalb eines IP-Adressbereichs (z.
         <libRML:libRML version="0.4" xmlns:libRML="http://librml.org/schema">
           <libRML:item commercialuse="false">
             <libRML:action type="displaymetadata" permission="true"/>
-            <libRML:action type="index" permission="true"/>
             <libRML:action type="archive" permission="true"/>
+            <libRML:action type="index" permission="true">
+              <libRML:restriction type="location" inside="SLUB"/>
+            </libRML:action>
             <libRML:action type="read" permission="true">
               <libRML:restriction type="location" inside="SLUB"/>
             </libRML:action>
@@ -105,8 +107,10 @@ Im folgenden Beispiel wird [Zugang nur innerhalb eines IP-Adressbereichs (z.B. C
     <libRML:libRML version="0.4" xmlns:libRML="http://librml.org/schema">
       <libRML:item commercialuse="false">
         <libRML:action type="displaymetadata" permission="true"/>
-        <libRML:action type="index" permission="true"/>
         <libRML:action type="archive" permission="true"/>
+        <libRML:action type="index" permission="true">
+          <libRML:restriction type="location" inside="SLUB"/>
+        </libRML:action>
         <libRML:action type="read" permission="true">
           <libRML:restriction type="location" inside="SLUB"/>
         </libRML:action>

--- a/usage/mapping.md
+++ b/usage/mapping.md
@@ -30,7 +30,9 @@ Ist die Prüfung positiv, werden die zugehörigen gültigen Beschränkungen im L
 <libRML:libRML xmlns:libRML="http://librml.org/schema">
     <libRML:item usageguide="https://nutzungshinweis.slub-dresden.de/ez-am-pr/1.0/">
         <libRML:action type="displaymetadata" permission="true"/>
-        <libRML:action type="index" permission="true"/>
+        <libRML:action type="index" permission="true">
+            <libRML:restriction type="location" inside="Lesesaal(Sammlungen)"/>
+        </libRML:action>
         <libRML:action type="read" permission="true">
             <libRML:restriction type="location" inside="Lesesaal(Sammlungen)"/>
         </libRML:action>
@@ -68,7 +70,9 @@ Ist die Prüfung positiv, werden die zugehörigen gültigen Beschränkungen im L
 <libRML:libRML xmlns:libRML="http://librml.org/schema">
     <libRML:item usageguide="https://nutzungshinweis.slub-dresden.de/ez-am/1.0/">
         <libRML:action type="displaymetadata" permission="true"/>
-        <libRML:action type="index" permission="true"/>
+        <libRML:action type="index" permission="true">
+            <libRML:restriction type="location" inside="SLUB-Arbeitsplätze"/>
+        </libRML:action>
         <libRML:action type="read" permission="true">
             <libRML:restriction type="location" inside="SLUB-Arbeitsplätze"/>
         </libRML:action>


### PR DESCRIPTION
This updates and further distinguishes the meanings and usage of `index` and `displaymetadata`.
`displaymetadata` is now virtually allowed anywhere, whereas `index` is further restricted alongside `read`.

Also the `section` attributes have been removed.

NB: I figured that we now don't need to specify the `filegroups` in the adjustment examples anymore, so I romved them. Correct? 