### PR TITLE
Update datatype for maxresolution

### DIFF
--- a/adjustments/adjustments_elements_existing.md
+++ b/adjustments/adjustments_elements_existing.md
@@ -171,8 +171,8 @@ Ziel ist unter anderem die Erstellung eines Anwendungsprofils für Retrodigitali
   * **Relevanz:** Unklar
   * **Bemerkung:** Dies wird nicht mit/in Kitodo.Presentation gesteuert und muss nicht maschinenlesbar beschrieben werden.
 * **maxresolution**
-  * **Relevanz:** Nein
-  * **Bemerkung:** Die Verwaltung der Qualität wird mit den METS-Dateigruppen realisiert, um technische Anpassungen an Kitodo.Presentation zu vermeiden.
+  * **Relevanz:** Unklar
+  * **Bemerkung:** Die Verwaltung der Qualität kann auch durch die METS-Dateigruppen realisiert werden.
 * **minage**
   * **Relevanz:** Nein
   * **Bemerkung:** Dies wird nicht mit/in Kitodo.Presentation gesteuert und muss nicht maschinenlesbar beschrieben werden.

--- a/examples/agreement.md
+++ b/examples/agreement.md
@@ -26,7 +26,7 @@ Zugang und Nutzung nur nach Einwilligung, zum Beispiel durch Abschluss eines Nut
 
 ```xml
 <?xml version="1.0" encoding="ASCII"?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item commercialuse="true" id="agreement-DE-447" template="Agreement" tenant="https://www.slub-dresden.de/">
     <action type="displaymetadata" permission="true"/>
     <action type="index" permission="true"/>

--- a/examples/authentification.md
+++ b/examples/authentification.md
@@ -20,7 +20,7 @@ Zugang und Nutzung nur nach Authentifizierung. In LibRML wird dies durch Zugehö
 
 ```xml
 <?xml version="1.0" encoding="ASCII"?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item commercialuse="true" id="auth-DE-442" template="Authentification" tenant="https://www.slub-dresden.de/">
     <action type="displaymetadata" permission="true"/>
     <action type="index" permission="true"/>

--- a/examples/concurrent.md
+++ b/examples/concurrent.md
@@ -20,7 +20,7 @@ Zugang und Nutzung ist auf eine bestimmte Menge gleichzeitiger Zugriffe beschrä
 
 ```xml
 <?xml version="1.0" encoding="ASCII"?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item commercialuse="true" id="concuracc-440" template="ConcurrentAccess" tenant="https://www.slub-dresden.de/">
     <action type="displaymetadata" permission="true"/>
     <action type="index" permission="true"/>

--- a/examples/copyright_openaccess.md
+++ b/examples/copyright_openaccess.md
@@ -14,7 +14,7 @@ Hinweis:
 
 ```xml
 <?xml version="1.0" encoding="ASCII"?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item copyright="true" id="copyright-oa-100" template="LibRML Copyright - Open Access" tenant="https://www.slub-dresden.de/" usageguide="http://librml.org/examples/copyright_openaccess">
     <action type="displaymetadata" permission="true"/>
     <action type="index" permission="true"/>

--- a/examples/copyright_restrictedaccess.md
+++ b/examples/copyright_restrictedaccess.md
@@ -14,7 +14,7 @@ Hinweis:
 
 ```xml
 <?xml version="1.0" encoding="ASCII"?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
     <item copyright="true" id="copyright-ra-100" template="LibRML Copyright - Restricted Access" tenant="https://www.slub-dresden.de/" usageguide="http://librml.org/examples/copyright_restrictedaccess">
         <action type="displaymetadata" permission="true"/>
         <action type="index" permission="true"/>

--- a/examples/digitization.md
+++ b/examples/digitization.md
@@ -17,7 +17,7 @@ Ein urheberrechtsbehaftetes digitales Objekt der [SLUB Dresden](https://www.slub
 
 ```xml
 <?xml version="1.0" ?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
     <item commercialuse="false" copyright="true" id="DE-611-HS-3665348" tenant="https://www.slub-dresden.de/">
         <action type="displaymetadata" permission="true"/>
         <action type="index" permission="true"/>

--- a/examples/duration.md
+++ b/examples/duration.md
@@ -15,7 +15,7 @@ Die Wiedergabe der Audio-/Videodatei ist ausschnittsweise erlaubt, jedoch maxima
 
 ```xml
 <?xml version="1.0" encoding="ASCII"?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item id="readonly-449" template="Read only" tenant="https://www.slub-dresden.de/">
     <action type="displaymetadata" permission="true"/>
     <action type="index" permission="true"/>

--- a/examples/embargo.md
+++ b/examples/embargo.md
@@ -22,7 +22,7 @@ Ab dem 1. Januar 2029 ist der Zugang dann uneingeschränkt möglich.
 
 ```xml
 <?xml version="1.0" encoding="ASCII"?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item commercialuse="false" id="embargo-28" template="IP" tenant="https://www.slub-dresden.de/">
     <action type="displaymetadata" permission="true"/>
     <action type="index" permission="true"/>

--- a/examples/embargo.md
+++ b/examples/embargo.md
@@ -77,7 +77,7 @@ Ab dem 1. Januar 2029 ist der Zugang dann uneingeschränkt möglich.
       "restrictions": [
         {
           "type": "quality",
-          "maxresolution": 72
+          "maxresolution": "72"
         },
         {
           "type": "date",
@@ -101,7 +101,7 @@ Ab dem 1. Januar 2029 ist der Zugang dann uneingeschränkt möglich.
       "restrictions": [
         {
           "type": "quality",
-          "maxresolution": 72
+          "maxresolution": "72"
         },
         {
           "type": "date",
@@ -125,7 +125,7 @@ Ab dem 1. Januar 2029 ist der Zugang dann uneingeschränkt möglich.
       "restrictions": [
         {
           "type": "quality",
-          "maxresolution": 72
+          "maxresolution": "72"
         },
         {
           "type": "date",

--- a/examples/location.md
+++ b/examples/location.md
@@ -20,7 +20,7 @@ Zugang und Nutzung nur innerhalb eines IP-Adressbereichs, wie zum Beispiel Campu
 
 ```xml
 <?xml version="1.0" encoding="ASCII"?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item commercialuse="false" id="iprestricted-444" template="IP" tenant="https://www.slub-dresden.de/">
     <action type="displaymetadata" permission="true"/>
     <action type="index" permission="true"/>

--- a/examples/metadataonly.md
+++ b/examples/metadataonly.md
@@ -13,7 +13,7 @@ Zugang nur zu Metadaten, eine weitere Nutzung (z.B. Ansicht und Download) des di
 
 ```xml
 <?xml version="1.0" encoding="ASCII"?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item id="metaonly-441" template="Metadata access only" tenant="https://www.slub-dresden.de/">
     <action type="displaymetadata" permission="true"/>
     <action type="index" permission="true"/>

--- a/examples/readonly.md
+++ b/examples/readonly.md
@@ -15,7 +15,7 @@ Zugang zum Objekt zur Ansicht ohne weitere Nutzungsmöglichkeiten, wie Speichern
 
 ```xml
 <?xml version="1.0" encoding="ASCII"?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item id="readonly-449" template="Read only" tenant="https://www.slub-dresden.de/">
     <action type="displaymetadata" permission="true"/>
     <action type="index" permission="true"/>

--- a/schema/actions.md
+++ b/schema/actions.md
@@ -9,7 +9,7 @@ In einer LibRML-Beschreibung muss jede erlaubte `action` ausdrücklich aufgefüh
 `action` können durch Einschränkungen [(siehe `Constraints`)](constraints.md) und Eigenschaften [(siehe `Attributes`)](attributes.md) spezifiziert werden.
 
 ```xml
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item id="ID-NAME">
     <action type="ACTION-NAME" permission="true" />
   </item>

--- a/schema/attributes.md
+++ b/schema/attributes.md
@@ -30,7 +30,7 @@ In LibRML stehen folgende Eigenschaften zur Verfügung.
 | maxage | Maximalalter für eine Action. Zum Beispiel in Einrichtungen genutzt, die Kinderbücher für Erwachsene unzugänglich machen. | positive integer | **Einheit**: Jahre |
 | maxbitrate | Maximal erlaubte Bitrate für den Download eines digitalen Objekts | positive integer | **Einheit**: Bit |
 | maxduration | Maximale Dauer eines Constraints | positive integer | **Einheit**: Sekunden |
-| maxresolution | Maximal erlaubte Auflösung für den Download eines digitalen Objekts | positive integer | **Einheit**: DPI |
+| maxresolution | Maximal erlaubte Auflösung für die Anzeige und den Download eines digitalen Objekts | positive integer | **Einheit**: DPI <br> Die Einheit kann auch angegeben werden, z.B. 150dpi, oder eine entsprechende Zeilenzahl für Videos festgelegt werden, z.B. 1080p oder 720i |
 | minage | Mindestalter für eine Action. Zum Beispiel zur Beschreibung des Jugendschutzes genutzt. | positive integer | **Einheit**: Jahre |
 | outside | Nutzung außerhalb eines geographischen Gebiets oder außerhalb einer Institution | Name | |
 | percentage | Teile des digitalen Objekts in Prozent. | nicht-negative integer | |

--- a/schema/concept.md
+++ b/schema/concept.md
@@ -34,7 +34,7 @@ Ein urheberrechtlich geschütztes digitales Objekt der [SLUB Dresden](https://ww
 Diesem digitalen Objekt würde folgende LibRML-Beschreibung zugewiesen werden.
 
 ```xml
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item commercialuse="false" copyright="true" id="access-0815" tenant="https://www.slub-dresden.de/">
     <action type="displaymetadata" permission="true" />
     <action type="index" permission="true" />

--- a/schema/constraints.md
+++ b/schema/constraints.md
@@ -214,7 +214,7 @@ In LibRML stehen folgende Einschränkungen zur Verfügung.
 
 ```xml
   <action type="print" permission="true">
-    <restriction type="quality" maxresolution="300" />
+    <restriction type="quality" maxresolution="300dpi" />
   </action>
 ```
 
@@ -224,7 +224,7 @@ In LibRML stehen folgende Einschränkungen zur Verfügung.
   "restrictions": [
     {
       "type": "quality",
-      "maxresolution": 300
+      "maxresolution": "300dpi"
     },
 ```
 

--- a/schema/header.md
+++ b/schema/header.md
@@ -43,7 +43,7 @@ Ein urheberrechtlich geschütztes digitales Objekt der SLUB Dresden erfordert ei
 Diesem Objekt würde folgender LibRML-Header zugewiesen:
 
 ```xml
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item copyright="true" id="id-123456" mention="true" sharealike="true" tenant="https://www.slub-dresden.de/">
   </item>
 </libRML>

--- a/schema/librml.json
+++ b/schema/librml.json
@@ -76,8 +76,8 @@
             "type": "integer"
           },
           "maxresolution": {
-            "minimum": 1,
-            "type": "integer"
+            "pattern": "[1-9]\\d*(dpi|i|p)?",
+            "type": "string"
           },
           "minage": {
             "minimum": 1,

--- a/schema/librml.xsd
+++ b/schema/librml.xsd
@@ -4,7 +4,7 @@
     xmlns:libRML="http://librml.org/schema"
     attributeFormDefault="unqualified"
     elementFormDefault="qualified"
-    version="0.5.0">
+    version="0.6.0">
     <xs:element name="libRML" type="libRML:libRMLType" />
 
     <!-- libRMLType - Container for all -->
@@ -116,7 +116,15 @@
         </xs:attribute>
     </xs:attributeGroup>
     <xs:attributeGroup name="qltattr">
-        <xs:attribute type="xs:positiveInteger" name="maxresolution" />
+        <xs:attribute name="maxresolution">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <!-- Regex for image and video resolution -->
+                    <xs:pattern
+                        value="[1-9]\d*(dpi|i|p)?" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
         <xs:attribute type="xs:positiveInteger" name="maxbitrate" />
     </xs:attributeGroup>
 </xs:schema>

--- a/templates/CC0.md
+++ b/templates/CC0.md
@@ -4,7 +4,7 @@
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item commercialuse="true" id="demo-mit-CC0" template="CC0-1.0" usageguide="https://creativecommons.org/publicdomain/zero/1.0/">
     <action type="displaymetadata" permission="true"/>
     <action type="index" permission="true"/>

--- a/templates/CCBY3DE.md
+++ b/templates/CCBY3DE.md
@@ -4,7 +4,7 @@
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item commercialuse="true" id="demo-mit-CCBYDE" mention="true" template="CC-BY-3.0-DE" usageguide="https://creativecommons.org/licenses/by/3.0/de/">
     <action type="displaymetadata" permission="true"/>
     <action type="index" permission="true"/>

--- a/templates/CCBY4.md
+++ b/templates/CCBY4.md
@@ -4,7 +4,7 @@
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item commercialuse="true" id="demo-mit-CCBY" mention="true" template="CC-BY-4.0" usageguide="https://creativecommons.org/licenses/by/4.0/">
     <action type="displaymetadata" permission="true"/>
     <action type="index" permission="true"/>

--- a/templates/CCBYNC3DE.md
+++ b/templates/CCBYNC3DE.md
@@ -4,7 +4,7 @@
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item commercialuse="false" id="demo-mit-CCBYNCDE" mention="true" template="CC-BY-NC-3.0-DE" usageguide="https://creativecommons.org/licenses/by-nc/3.0/de/">
     <action type="displaymetadata" permission="true"/>
     <action type="index" permission="true"/>

--- a/templates/CCBYNC4.md
+++ b/templates/CCBYNC4.md
@@ -4,7 +4,7 @@
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item commercialuse="false" id="demo-mit-CCBYNC" mention="true" template="CC-BY-NC-4.0" usageguide="https://creativecommons.org/licenses/by-nc/4.0/">
     <action type="displaymetadata" permission="true"/>
     <action type="index" permission="true"/>

--- a/templates/CCBYNCND3DE.md
+++ b/templates/CCBYNCND3DE.md
@@ -4,7 +4,7 @@
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item commercialuse="false" id="demo-mit-CCBYNCNDDE" mention="true" template="CC-BY-NC-ND-3.0-DE" usageguide="https://creativecommons.org/licenses/by-nc-nd/3.0/de/">
     <action type="displaymetadata" permission="true"/>
     <action type="index" permission="true"/>

--- a/templates/CCBYNCND4.md
+++ b/templates/CCBYNCND4.md
@@ -4,7 +4,7 @@
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item commercialuse="false" id="demo-mit-CCBYNCND" mention="true" template="CC-BY-NC-ND-4.0" usageguide="https://creativecommons.org/licenses/by-nc-nd/4.0/">
     <action type="displaymetadata" permission="true"/>
     <action type="index" permission="true"/>

--- a/templates/CCBYNCSA3DE.md
+++ b/templates/CCBYNCSA3DE.md
@@ -4,7 +4,7 @@
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item commercialuse="false" id="demo-mit-CCBYNCSADE" mention="true" sharealike="true" template="CC-BY-NC-SA-3.0-DE" usageguide="https://creativecommons.org/licenses/by-nc-sa/3.0/de/">
     <action type="displaymetadata" permission="true"/>
     <action type="index" permission="true"/>

--- a/templates/CCBYNCSA4.md
+++ b/templates/CCBYNCSA4.md
@@ -4,7 +4,7 @@
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item commercialuse="false" id="demo-mit-CCBYNCSA" mention="true" sharealike="true" template="CC-BY-NC-SA-4.0" usageguide="https://creativecommons.org/licenses/by-nc-sa/4.0/">
     <action type="displaymetadata" permission="true"/>
     <action type="index" permission="true"/>

--- a/templates/CCBYND3DE.md
+++ b/templates/CCBYND3DE.md
@@ -4,7 +4,7 @@
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item commercialuse="true" id="demo-mit-CCBYNDDE" mention="true" template="CC-BY-ND-3.0-DE" usageguide="https://creativecommons.org/licenses/by-nd/3.0/de/">
     <action type="displaymetadata" permission="true"/>
     <action type="index" permission="true"/>

--- a/templates/CCBYND4.md
+++ b/templates/CCBYND4.md
@@ -4,7 +4,7 @@
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item commercialuse="true" id="demo-mit-CCBYND" mention="true" template="CC-BY-ND-4.0" usageguide="https://creativecommons.org/licenses/by-nd/4.0/">
     <action type="displaymetadata" permission="true"/>
     <action type="index" permission="true"/>

--- a/templates/CCBYSA3DE.md
+++ b/templates/CCBYSA3DE.md
@@ -4,7 +4,7 @@
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item commercialuse="true" id="demo-mit-CCBYSADE" mention="true" sharealike="true" template="CC-BY-SA-4.0" usageguide="https://creativecommons.org/licenses/by-sa/4.0/">
     <action type="displaymetadata" permission="true"/>
     <action type="index" permission="true"/>

--- a/templates/CCBYSA4.md
+++ b/templates/CCBYSA4.md
@@ -4,7 +4,7 @@
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item commercialuse="true" id="demo-mit-CCBYSA" mention="true" sharealike="true" template="CC-BY-SA-4.0" usageguide="https://creativecommons.org/licenses/by-sa/4.0/">
     <action type="displaymetadata" permission="true"/>
     <action type="index" permission="true"/>

--- a/templates/DLDEBY2.md
+++ b/templates/DLDEBY2.md
@@ -4,7 +4,7 @@
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item commercialuse="true" id="demo-mit-DL-DE-BY-2.0" mention="true" template="DL-DE-BY-2.0" usageguide="http://www.govdata.de/dl-de/by-2-0">
     <action type="displaymetadata" permission="true"/>
     <action type="index" permission="true"/>

--- a/templates/DLDEzero2.md
+++ b/templates/DLDEzero2.md
@@ -4,7 +4,7 @@
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item commercialuse="true" id="demo-mit-DL-DE-Zero-2.0" template="DL-DE-ZERO-2.0" usageguide="http://www.govdata.de/dl-de/zero-2-0">
     <action type="displaymetadata" permission="true"/>
     <action type="index" permission="true"/>

--- a/templates/PDM1.md
+++ b/templates/PDM1.md
@@ -4,7 +4,7 @@
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
-<libRML version="0.4" xmlns="http://librml.org/schema">
+<libRML version="0.6" xmlns="http://librml.org/schema">
   <item commercialuse="true" copyright="false" id="ID-PD.M1" template="CC-PDM-1.0" usageguide="https://creativecommons.org/publicdomain/mark/1.0/">
     <action type="displaymetadata" permission="true"/>
     <action type="index" permission="true"/>

--- a/usage/embedded.md
+++ b/usage/embedded.md
@@ -51,7 +51,7 @@ In dem folgenden Beispiel wird [Zugang nur innerhalb eines IP-Adressbereichs (z.
   <mets:amdSec>
     <mets:rightsMD ID="LibRML">
       <mets:mdWrap MDTYPE="OTHER" MIMETYPE="text/xml" OTHERMDTYPE="LibRML">
-        <libRML:libRML version="0.4" xmlns:libRML="http://librml.org/schema">
+        <libRML:libRML version="0.6" xmlns:libRML="http://librml.org/schema">
           <libRML:item commercialuse="false">
             <libRML:action type="displaymetadata" permission="true"/>
             <libRML:action type="index" permission="true"/>
@@ -102,7 +102,7 @@ Im folgenden Beispiel wird [Zugang nur innerhalb eines IP-Adressbereichs (z.B. C
 ```xml
 <mods:mods xmlns:mods="http://www.loc.gov/mods/v3">
   <mods:accessCondition type="LibRML">
-    <libRML:libRML version="0.4" xmlns:libRML="http://librml.org/schema">
+    <libRML:libRML version="0.6" xmlns:libRML="http://librml.org/schema">
       <libRML:item commercialuse="false">
         <libRML:action type="displaymetadata" permission="true"/>
         <libRML:action type="index" permission="true"/>


### PR DESCRIPTION
This changes the schema in order to also allow video resoltions to be specified.

Now it is imossible to add "dpi" after the number (e.g., "300dpi"), or an "i"/"p" for video streams (i.e. "interlaced" and "progressive").

Open questions:

* should the unit be mandatory?
* should the value at least have two digits? (A resolution of "8" doesn't seem to make much sense.)
* should more units be allowed (e.g., "ppi"), and if yes, which ones?

NB: Moves the schema version from 0.5 to 0.6.