### PR TITLE
Add maxdimension with pixels as unit

### DIFF
--- a/examples/embargo.md
+++ b/examples/embargo.md
@@ -28,21 +28,21 @@ Ab dem 1. Januar 2029 ist der Zugang dann uneingeschränkt möglich.
     <action type="index" permission="true"/>
     <action type="archive" permission="true"/>
     <action type="read" permission="true">
-      <restriction type="quality" maxresolution="72"/>
+      <restriction type="quality" maxresolution="300"/>
       <restriction type="date" todate="2028-12-31"/>
     </action>
     <action type="read" permission="true">
       <restriction type="date" fromdate="2029-01-01"/>
     </action>
     <action type="download" permission="true">
-      <restriction type="quality" maxresolution="72"/>
+      <restriction type="quality" maxresolution="300"/>
       <restriction type="date" todate="2028-12-31"/>
     </action>
     <action type="download" permission="true">
       <restriction type="date" fromdate="2029-01-01"/>
     </action>
     <action type="print" permission="true">
-      <restriction type="quality" maxresolution="72"/>
+      <restriction type="quality" maxresolution="300"/>
       <restriction type="date" todate="2028-12-31"/>
     </action>
     <action type="print" permission="true">
@@ -77,7 +77,7 @@ Ab dem 1. Januar 2029 ist der Zugang dann uneingeschränkt möglich.
       "restrictions": [
         {
           "type": "quality",
-          "maxresolution": 72
+          "maxresolution": 300
         },
         {
           "type": "date",
@@ -101,7 +101,7 @@ Ab dem 1. Januar 2029 ist der Zugang dann uneingeschränkt möglich.
       "restrictions": [
         {
           "type": "quality",
-          "maxresolution": 72
+          "maxresolution": 300
         },
         {
           "type": "date",
@@ -125,7 +125,7 @@ Ab dem 1. Januar 2029 ist der Zugang dann uneingeschränkt möglich.
       "restrictions": [
         {
           "type": "quality",
-          "maxresolution": 72
+          "maxresolution": 300
         },
         {
           "type": "date",

--- a/schema/attributes.md
+++ b/schema/attributes.md
@@ -30,7 +30,7 @@ In LibRML stehen folgende Eigenschaften zur Verfügung.
 | maxage | Maximalalter für eine Action. Zum Beispiel in Einrichtungen genutzt, die Kinderbücher für Erwachsene unzugänglich machen. | positive integer | **Einheit**: Jahre |
 | maxbitrate | Maximal erlaubte Bitrate für den Download eines digitalen Objekts | positive integer | **Einheit**: Bit |
 | maxduration | Maximale Dauer eines Constraints | positive integer | **Einheit**: Sekunden |
-| maxresolution | Maximal erlaubte Auflösung für den Download eines digitalen Objekts | positive integer | **Einheit**: DPI |
+| maxresolution | Maximal erlaubte Auflösung für die Anzeige und den Download eines digitalen Objekts, bestimmt durch die Anzahl der Pixel einer Seitenlänge | positive integer | **Einheit**: px |
 | minage | Mindestalter für eine Action. Zum Beispiel zur Beschreibung des Jugendschutzes genutzt. | positive integer | **Einheit**: Jahre |
 | outside | Nutzung außerhalb eines geographischen Gebiets oder außerhalb einer Institution | Name | |
 | percentage | Teile des digitalen Objekts in Prozent. | nicht-negative integer | |

--- a/schema/attributes.md
+++ b/schema/attributes.md
@@ -29,8 +29,9 @@ In LibRML stehen folgende Eigenschaften zur Verfügung.
 | inside | Nutzung innerhalb eines geographischen Gebiets oder innerhalb einer Institution | Name | |
 | maxage | Maximalalter für eine Action. Zum Beispiel in Einrichtungen genutzt, die Kinderbücher für Erwachsene unzugänglich machen. | positive integer | **Einheit**: Jahre |
 | maxbitrate | Maximal erlaubte Bitrate für den Download eines digitalen Objekts | positive integer | **Einheit**: Bit |
+| maxdimension | Maximale erlaubte Größe (der längeren Seite) eines digitalen Objekts | positive integer | **Einheit**: Pixel |
 | maxduration | Maximale Dauer eines Constraints | positive integer | **Einheit**: Sekunden |
-| maxresolution | Maximal erlaubte Auflösung für die Anzeige und den Download eines digitalen Objekts, bestimmt durch die Anzahl der Pixel einer Seitenlänge | positive integer | **Einheit**: px |
+| maxresolution | Maximal erlaubte Auflösung für den Download eines digitalen Objekts | positive integer | **Einheit**: DPI |
 | minage | Mindestalter für eine Action. Zum Beispiel zur Beschreibung des Jugendschutzes genutzt. | positive integer | **Einheit**: Jahre |
 | outside | Nutzung außerhalb eines geographischen Gebiets oder außerhalb einer Institution | Name | |
 | percentage | Teile des digitalen Objekts in Prozent. | nicht-negative integer | |

--- a/schema/constraints.md
+++ b/schema/constraints.md
@@ -214,7 +214,7 @@ In LibRML stehen folgende Einschränkungen zur Verfügung.
 
 ```xml
   <action type="print" permission="true">
-    <restriction type="quality" maxresolution="300" />
+    <restriction type="quality" maxresolution="1080" />
   </action>
 ```
 
@@ -224,7 +224,7 @@ In LibRML stehen folgende Einschränkungen zur Verfügung.
   "restrictions": [
     {
       "type": "quality",
-      "maxresolution": 300
+      "maxresolution": 1080
     },
 ```
 

--- a/schema/dependencies.md
+++ b/schema/dependencies.md
@@ -15,5 +15,5 @@ In der folgendenden Tabelle sind die erlaubten Kombinationen von Einschränkunge
 | group | groups | alle außer `archive` `displaymetadata` `move` |
 | location | inside <br> outside <br> subnet | alle |
 | parts | percentage | alle außer `displaymetadata` `index` |
-| quality | maxbitrate <br> maxresolution | alle außer `archive` `displaymetadata` `index` `move` |
+| quality | maxbitrate <br> maxdimension <br> maxresolution | alle außer `archive` `displaymetadata` `index` `move` |
 | watermark | watermarkvalue | alle außer `displaymetadata` |

--- a/schema/librml.json
+++ b/schema/librml.json
@@ -71,6 +71,10 @@
             "minimum": 1,
             "type": "integer"
           },
+          "maxdimension": {
+            "minimum": 1,
+            "type": "integer"
+          },
           "maxduration": {
             "minimum": 1,
             "type": "integer"

--- a/schema/librml.xsd
+++ b/schema/librml.xsd
@@ -116,7 +116,8 @@
         </xs:attribute>
     </xs:attributeGroup>
     <xs:attributeGroup name="qltattr">
-        <xs:attribute type="xs:positiveInteger" name="maxresolution" />
         <xs:attribute type="xs:positiveInteger" name="maxbitrate" />
+        <xs:attribute type="xs:positiveInteger" name="maxdimension" />
+        <xs:attribute type="xs:positiveInteger" name="maxresolution" />
     </xs:attributeGroup>
 </xs:schema>


### PR DESCRIPTION
This PR changes the unit for `maxresolution`  from `dpi` to `px`.

NB: For now it specifies this to be the maximal length in pixels of one side of the digital object. We may need to clarify it to apply only to the height or the width. 