### PR TITLE
Update displaymetadata in adjustments

### DIFF
--- a/adjustments/adjustments_elements_existing.md
+++ b/adjustments/adjustments_elements_existing.md
@@ -15,11 +15,7 @@ Ziel ist unter anderem die Erstellung eines Anwendungsprofils für Retrodigitali
   * **Relevanz:** Ja
   * **Bemerkung:**
     * Metadaten einschließlich der Nutzungshinweise werden in den Digitalen Sammlungen angezeigt, auch wenn die Objekte nicht frei zugänglich sind.
-    * Dies betrifft die Listenansicht und Werkansicht.
-  * **Beispiele:**
-    * [Eingeschränkter Zugang - Arbeitsplätze Mediathek - Unter Aufsicht](/adjustments/aufsicht.md)
-    * [Künstlerbücher](/adjustments/kuenstlerbuecher.md)
-    * [Sächsische Zeitung](/adjustments/saechsischezeitung.md)
+    * Kann in Systemen, die zwischen Katalogebene und Präsentationsebene unterscheiden, nicht sinnvoll eingesetzt werden.
 * **distribute**
   * **Relevanz:** Nein
   * **Bemerkung:**

--- a/adjustments/adjustments_elements_new.md
+++ b/adjustments/adjustments_elements_new.md
@@ -13,7 +13,6 @@ Bestandteile der METS-Dateien, die zur Beschreibung der Beschränkungen in LibRM
 
 Anwendbar in den folgenden [Actions](/schema/actions.md):
 
-* `displaymetadata`
 * `download`
 * `index`
 * `read`

--- a/adjustments/saechsischezeitung.md
+++ b/adjustments/saechsischezeitung.md
@@ -14,9 +14,7 @@ Umsetzung mit dem derzeit gültigen LibRML-Modell
             <mets:mdWrap MDTYPE="OTHER" MIMETYPE="text/xml" OTHERMDTYPE="LibRML">
                 <libRML:libRML xmlns:libRML="http://librml.org/schema">
                     <libRML:item usageguide="https://nutzungshinweis.slub-dresden.de/sc-zt/1.0/">
-                        <libRML:action type="displaymetadata" permission="true">
-                            <libRML:restriction type="group" groups="SLUB-Nutzende"/>
-                        </libRML:action>
+                        <libRML:action type="displaymetadata" permission="true"/>
                         <libRML:action type="download" permission="true">
                             <libRML:restriction type="group" groups="SLUB-Nutzende"/>
                         </libRML:action>
@@ -47,9 +45,7 @@ Umsetzung mit einem angepassten LibRML-Modell
             <mets:mdWrap MDTYPE="OTHER" MIMETYPE="text/xml" OTHERMDTYPE="LibRML">
                 <libRML:libRML xmlns:libRML="http://librml.org/schema">
                     <libRML:item usageguide="https://nutzungshinweis.slub-dresden.de/sc-zt/1.0/">
-                        <libRML:action type="displaymetadata" permission="true">
-                            <libRML:restriction type="group" groups="SLUB-Nutzende"/>
-                        </libRML:action>
+                        <libRML:action type="displaymetadata" permission="true"/>
                         <libRML:action type="download" permission="true">
                             <libRML:restriction type="group" groups="SLUB-Nutzende"/>
                             <libRML:restriction type="mets" filegroups="DOWNLOAD ORIGINAL"/>


### PR DESCRIPTION
After our discussion we agreed, that there isn't a proper usecase nor a technical feasibility for `displaymetadata`.

I've updated the examples for our "adjustments".
Yet I'm not sure if we should keep displaymetadata anyway.